### PR TITLE
Do not serialize None values

### DIFF
--- a/core_utils/serialization.py
+++ b/core_utils/serialization.py
@@ -58,10 +58,16 @@ def serialize(value: Any, custom: Optional[CustomFormat] = None) -> Any:
         return custom[type(value)](value)
 
     elif is_namedtuple(value):
-        return {k: serialize(raw_val, custom) for k, raw_val in value._asdict().items()}
+        return {
+            k: serialize(raw_val, custom)
+            for k, raw_val in value._asdict().items()
+            if raw_val is not None
+        }
 
     elif is_dataclass(value):
-        return {k: serialize(v, custom) for k, v in value.__dict__.items()}
+        return {
+            k: serialize(v, custom) for k, v in value.__dict__.items() if v is not None
+        }
 
     elif isinstance(value, Mapping):
         return {serialize(k, custom): serialize(v, custom) for k, v in value.items()}

--- a/core_utils/serialization.py
+++ b/core_utils/serialization.py
@@ -38,7 +38,9 @@ See uses in :func:`serialize` and :func:`deserialize`.
 """
 
 
-def serialize(value: Any, custom: Optional[CustomFormat] = None) -> Any:
+def serialize(
+    value: Any, custom: Optional[CustomFormat] = None, no_none_values: bool = True
+) -> Any:
     """Attempts to convert the `value` into an equivalent `dict` structure.
 
     NOTE: If the value is not a namedtuple, dataclass, mapping, enum, or iterable, then the value is
@@ -49,6 +51,11 @@ def serialize(value: Any, custom: Optional[CustomFormat] = None) -> Any:
     ```
     custom = {numpy.ndarray: lambda a: a.tolist()}
     ```
+
+    The :param:`no_none_values` flag controls whether or not this function will explicitly serialize
+    fields of dataclasses and namedtuples or key-value mappings where the value is `None`. By default,
+    such `None` values are ignored and their respective key-value entry will be exlcuded from returned
+    serialized result. Otherwise, they are kept in the returned serialized result as `None`s.
 
     NOTE: If :param:`custom` is present, its serialization functions are given priority.
     NOTE: If using :param:`custom` for generic types, you *must* have unique instances for each possible
@@ -61,16 +68,22 @@ def serialize(value: Any, custom: Optional[CustomFormat] = None) -> Any:
         return {
             k: serialize(raw_val, custom)
             for k, raw_val in value._asdict().items()
-            if raw_val is not None
+            if (no_none_values and raw_val is not None) or (not no_none_values)
         }
 
     elif is_dataclass(value):
         return {
-            k: serialize(v, custom) for k, v in value.__dict__.items() if v is not None
+            k: serialize(v, custom)
+            for k, v in value.__dict__.items()
+            if (no_none_values and v is not None) or (not no_none_values)
         }
 
     elif isinstance(value, Mapping):
-        return {serialize(k, custom): serialize(v, custom) for k, v in value.items()}
+        return {
+            serialize(k, custom): serialize(v, custom)
+            for k, v in value.items()
+            if (no_none_values and v is not None) or (not no_none_values)
+        }
 
     elif isinstance(value, Iterable) and not isinstance(value, str):
         return list(map(lambda x: serialize(x, custom), value))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pywise"
-version = "0.1.2"
+version = "0.2.0"
 description = "Robust serialization support for NamedTuple & @dataclass data types."
 authors = ["Malcolm Greaves <greaves.malcolm@gmail.com>"]
 homepage = "https://github.com/malcolmgreaves/pywise"

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -333,6 +333,18 @@ def test_union_deserialization_nt():
     _test_union_deserialization(X1_NT, LS_NT)
 
 
+def test_serialize_none_doesnt_show_nt():
+    class HasNone_NT(NamedTuple):
+        fieldname: Optional[str]
+
+    x = HasNone_NT("world")
+    assert deserialize(HasNone_NT, serialize(x)) == x
+
+    s = serialize(HasNone_NT(None))
+    assert len(s) == 0
+    assert deserialize(HasNone_NT, s) == HasNone_NT(None)
+
+
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 #                            Dataclass Tests                        #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
@@ -449,3 +461,16 @@ def test_union_deserialization_dc():
         values: Union[LS_DC, int]
 
     _test_union_deserialization(X1_DC, LS_DC)
+
+
+def test_serialize_none_doesnt_show_dc():
+    @dataclass
+    class HasNone_DC:
+        fieldname: Optional[str]
+
+    x = HasNone_DC("world")
+    assert deserialize(HasNone_DC, serialize(x)) == x
+
+    s = serialize(HasNone_DC(None))
+    assert len(s) == 0
+    assert deserialize(HasNone_DC, s) == HasNone_DC(None)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -333,7 +333,7 @@ def test_union_deserialization_nt():
     _test_union_deserialization(X1_NT, LS_NT)
 
 
-def test_serialize_none_doesnt_show_nt():
+def test_serialize_none_special_cases_nt():
     class HasNone_NT(NamedTuple):
         fieldname: Optional[str]
 
@@ -342,6 +342,10 @@ def test_serialize_none_doesnt_show_nt():
 
     s = serialize(HasNone_NT(None))
     assert len(s) == 0
+    assert deserialize(HasNone_NT, s) == HasNone_NT(None)
+
+    s = serialize(HasNone_NT(None), no_none_values=False)
+    assert len(s) == 1
     assert deserialize(HasNone_NT, s) == HasNone_NT(None)
 
 
@@ -463,7 +467,7 @@ def test_union_deserialization_dc():
     _test_union_deserialization(X1_DC, LS_DC)
 
 
-def test_serialize_none_doesnt_show_dc():
+def test_serialize_none_special_cases_dc():
     @dataclass
     class HasNone_DC:
         fieldname: Optional[str]
@@ -473,4 +477,8 @@ def test_serialize_none_doesnt_show_dc():
 
     s = serialize(HasNone_DC(None))
     assert len(s) == 0
+    assert deserialize(HasNone_DC, s) == HasNone_DC(None)
+
+    s = serialize(HasNone_DC(None), no_none_values=False)
+    assert len(s) == 1
     assert deserialize(HasNone_DC, s) == HasNone_DC(None)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -482,3 +482,14 @@ def test_serialize_none_special_cases_dc():
     s = serialize(HasNone_DC(None), no_none_values=False)
     assert len(s) == 1
     assert deserialize(HasNone_DC, s) == HasNone_DC(None)
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+#                            Extra Tests                            #
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+def test_serialize_none_special_cases_mapping():
+    m_empty = {"key": None}
+    s = serialize(m_empty, no_none_values=False)
+    assert len(s) == 1
+    assert deserialize(Mapping[str, Optional[int]], s) == m_empty
+    assert deserialize(Mapping[str, Optional[int]], serialize(m_empty)) == {}


### PR DESCRIPTION
Changes the default behavior of `serialize` to not explicitly serialize values that are `None` in `@dataclass`es, `NamedTuple`-derriving classes, or key-value `Mapping`s. When combining with JSON serialization, this will prevent a `"field_name": null` object key-value mapping from coming up.

To explicitly serialize `None` values (i.e. the old behavior), the new `no_none_values` flag can be set to `False`. New tests have been added to cover this new behavior.

Major API change, but in keeping with Semantic Versioning 2.0 rules for pre-releases (`0.x.x`), new version is `0.2.0`.