### PR TITLE
Enable deserialization support for dataclasses with generic types

### DIFF
--- a/core_utils/common.py
+++ b/core_utils/common.py
@@ -27,7 +27,7 @@ def type_name(t: type, keep_main: bool = True) -> str:
     if issubclass(type(t), _GenericAlias):
         return str(t)
 
-    if isinstance(t, TypeVar):
+    if isinstance(t, TypeVar):  # type: ignore
         return str(t)
 
     full_name = f"{mod}.{t.__name__}"

--- a/core_utils/common.py
+++ b/core_utils/common.py
@@ -1,7 +1,44 @@
 from importlib import import_module
-from typing import _GenericAlias, Any, Tuple, Optional, Type  # type: ignore
+from typing import _GenericAlias, Any, Tuple, Optional, Type , _type_repr # type: ignore
 
 
+# def type_name(t: type, keep_main: bool = True) -> str:
+#     """Complete name, module & specific type name, for the given type.
+#     Does not supply the module in the returned complete name for built-in types.
+#
+#     When possible, also adds generic type arguments (w/ their at-runtime values)
+#     in the returned full type name.
+#     """
+#     # TODO: Replace function with `typing._type_repr` ???
+#     mod = t.__module__
+#     if mod == "builtins":
+#         return t.__name__
+#
+#     if str(t).startswith("typing.Union"):
+#         try:
+#             args = t.__args__  # type: ignore
+#             if len(args) == 2 and args[1] == type(None):  # noqa: E721
+#                 # an Optional type is equivalent to Union[T, None]
+#                 return f"typing.Optional[{type_name(args[0])}]"
+#         except Exception:
+#             pass
+#         return str(t)
+#
+#     if issubclass(type(t), _GenericAlias):
+#         return str(t)
+#
+#     full_name = f"{mod}.{t.__name__}"
+#     try:
+#         # generic parameters ?
+#         args = tuple(map(type_name, t.__args__))  # type: ignore
+#         a = ", ".join(args)
+#         complete_type_name = f"{full_name}[{a}]"
+#     except Exception:
+#         complete_type_name = full_name
+#
+#     if not keep_main:
+#         complete_type_name = complete_type_name.replace("__main__.", "")
+#     return complete_type_name
 def type_name(t: type, keep_main: bool = True) -> str:
     """Complete name, module & specific type name, for the given type.
     Does not supply the module in the returned complete name for built-in types.
@@ -9,33 +46,7 @@ def type_name(t: type, keep_main: bool = True) -> str:
     When possible, also adds generic type arguments (w/ their at-runtime values)
     in the returned full type name.
     """
-    # TODO: Replace function with `typing._type_repr` ???
-    mod = t.__module__
-    if mod == "builtins":
-        return t.__name__
-
-    if str(t).startswith("typing.Union"):
-        try:
-            args = t.__args__  # type: ignore
-            if len(args) == 2 and args[1] == type(None):  # noqa: E721
-                # an Optional type is equivalent to Union[T, None]
-                return f"typing.Optional[{type_name(args[0])}]"
-        except Exception:
-            pass
-        return str(t)
-
-    if issubclass(type(t), _GenericAlias):
-        return str(t)
-
-    full_name = f"{mod}.{t.__name__}"
-    try:
-        # generic parameters ?
-        args = tuple(map(type_name, t.__args__))  # type: ignore
-        a = ", ".join(args)
-        complete_type_name = f"{full_name}[{a}]"
-    except Exception:
-        complete_type_name = full_name
-
+    complete_type_name = _type_repr(t)
     if not keep_main:
         complete_type_name = complete_type_name.replace("__main__.", "")
     return complete_type_name

--- a/core_utils/common.py
+++ b/core_utils/common.py
@@ -1,44 +1,7 @@
 from importlib import import_module
-from typing import _GenericAlias, Any, Tuple, Optional, Type , _type_repr # type: ignore
+from typing import _GenericAlias, Any, Tuple, Optional, Type, _type_repr  # type: ignore
 
 
-# def type_name(t: type, keep_main: bool = True) -> str:
-#     """Complete name, module & specific type name, for the given type.
-#     Does not supply the module in the returned complete name for built-in types.
-#
-#     When possible, also adds generic type arguments (w/ their at-runtime values)
-#     in the returned full type name.
-#     """
-#     # TODO: Replace function with `typing._type_repr` ???
-#     mod = t.__module__
-#     if mod == "builtins":
-#         return t.__name__
-#
-#     if str(t).startswith("typing.Union"):
-#         try:
-#             args = t.__args__  # type: ignore
-#             if len(args) == 2 and args[1] == type(None):  # noqa: E721
-#                 # an Optional type is equivalent to Union[T, None]
-#                 return f"typing.Optional[{type_name(args[0])}]"
-#         except Exception:
-#             pass
-#         return str(t)
-#
-#     if issubclass(type(t), _GenericAlias):
-#         return str(t)
-#
-#     full_name = f"{mod}.{t.__name__}"
-#     try:
-#         # generic parameters ?
-#         args = tuple(map(type_name, t.__args__))  # type: ignore
-#         a = ", ".join(args)
-#         complete_type_name = f"{full_name}[{a}]"
-#     except Exception:
-#         complete_type_name = full_name
-#
-#     if not keep_main:
-#         complete_type_name = complete_type_name.replace("__main__.", "")
-#     return complete_type_name
 def type_name(t: type, keep_main: bool = True) -> str:
     """Complete name, module & specific type name, for the given type.
     Does not supply the module in the returned complete name for built-in types.

--- a/core_utils/common.py
+++ b/core_utils/common.py
@@ -1,5 +1,5 @@
 from importlib import import_module
-from typing import _GenericAlias, Any, Tuple, Optional, Type, TypeVar  # type: ignore
+from typing import _GenericAlias, Any, Tuple, Optional, Type  # type: ignore
 
 
 def type_name(t: type, keep_main: bool = True) -> str:
@@ -10,41 +10,35 @@ def type_name(t: type, keep_main: bool = True) -> str:
     in the returned full type name.
     """
     # TODO: Replace function with `typing._type_repr` ???
-    def f():
-        mod = t.__module__
-        if mod == "builtins":
-            return t.__name__
+    mod = t.__module__
+    if mod == "builtins":
+        return t.__name__
 
-        if str(t).startswith("typing.Union"):
-            try:
-                args = t.__args__  # type: ignore
-                if len(args) == 2 and args[1] == type(None):  # noqa: E721
-                    # an Optional type is equivalent to Union[T, None]
-                    return f"typing.Optional[{type_name(args[0])}]"
-            except Exception:
-                pass
-            return str(t)
-
-        if issubclass(type(t), _GenericAlias):
-            return str(t)
-
-        if isinstance(t, TypeVar):
-            return f"~{t.__name__}"
-
-        full_name = f"{mod}.{t.__name__}"
+    if str(t).startswith("typing.Union"):
         try:
-            # generic parameters ?
-            args = tuple(map(type_name, t.__args__))  # type: ignore
-            a = ", ".join(args)
-            return f"{full_name}[{a}]"
+            args = t.__args__  # type: ignore
+            if len(args) == 2 and args[1] == type(None):  # noqa: E721
+                # an Optional type is equivalent to Union[T, None]
+                return f"typing.Optional[{type_name(args[0])}]"
         except Exception:
-            return full_name
+            pass
+        return str(t)
 
-    if keep_main:
-        return f()
-    else:
-        fn = f()
-        return fn.replace("__main__.", "")
+    if issubclass(type(t), _GenericAlias):
+        return str(t)
+
+    full_name = f"{mod}.{t.__name__}"
+    try:
+        # generic parameters ?
+        args = tuple(map(type_name, t.__args__))  # type: ignore
+        a = ", ".join(args)
+        complete_type_name = f"{full_name}[{a}]"
+    except Exception:
+        complete_type_name = full_name
+
+    if not keep_main:
+        complete_type_name = complete_type_name.replace("__main__.", "")
+    return complete_type_name
 
 
 def import_by_name(full_name: str, validate: bool = True) -> Any:

--- a/core_utils/common.py
+++ b/core_utils/common.py
@@ -1,5 +1,5 @@
 from importlib import import_module
-from typing import _GenericAlias, Any, Tuple, Optional, Type, _type_repr, TypeVar  # type: ignore
+from typing import _GenericAlias, Any, Tuple, Optional, Type, TypeVar  # type: ignore
 
 
 def type_name(t: type, keep_main: bool = True) -> str:

--- a/core_utils/common.py
+++ b/core_utils/common.py
@@ -2,7 +2,7 @@ from importlib import import_module
 from typing import _GenericAlias, Any, Tuple, Optional, Type, TypeVar  # type: ignore
 
 
-def type_name(t: type, keep_main:bool = True) -> str:
+def type_name(t: type, keep_main: bool = True) -> str:
     """Complete name, module & specific type name, for the given type.
     Does not supply the module in the returned complete name for built-in types.
 
@@ -44,7 +44,7 @@ def type_name(t: type, keep_main:bool = True) -> str:
         return f()
     else:
         fn = f()
-        return fn.replace('__main__.', '')
+        return fn.replace("__main__.", "")
 
 
 def import_by_name(full_name: str, validate: bool = True) -> Any:

--- a/core_utils/serialization.py
+++ b/core_utils/serialization.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import (  # type: ignore
+from typing import (
     Any,
     Iterable,
     Type,
@@ -11,7 +11,6 @@ from typing import (  # type: ignore
     Optional,
     Iterator,
     Sequence,
-    Union,
 )
 from dataclasses import dataclass, is_dataclass, Field
 
@@ -403,8 +402,8 @@ def _exec(origin_type, tn):
     m_bits = module.split(".")
     # fmt: off
     e_str = (
-        f"import typing\n"
-        f"from typing import *\n"
+        "import typing\n"
+        "from typing import *\n"
     )
     # fmt: on
     for i in range(1, len(m_bits)):

--- a/core_utils/serialization.py
+++ b/core_utils/serialization.py
@@ -424,7 +424,10 @@ def _exec(origin_type, tn):
     )
     # fmt: on
     namespace = globals().copy()
-    exec(e_str, namespace)
+    try:
+        exec(e_str, namespace)
+    except Exception as e:
+        raise ValueError(f"ERROR: tried to reify type with:\n{e_str}", e)
     typ = namespace[____typ]
     return typ
 

--- a/core_utils/serialization.py
+++ b/core_utils/serialization.py
@@ -127,7 +127,7 @@ def deserialize(
     if type_value == Any:
         return value
 
-    if isinstance(type_value, TypeVar):
+    if isinstance(type_value, TypeVar):  # type: ignore
         # is a generic type alias: cannot do much with this, so return as-is
         return value
 
@@ -345,7 +345,7 @@ def _dataclass_field_types(dataclass_type: Type) -> Iterable[Tuple[str, Type]]:
     else:
         dataclass_fields = dataclass_type.__dataclass_fields__  # type: ignore
 
-        def as_name_and_type(data_field):
+        def as_name_and_type(data_field: Field) -> Tuple[str, Type]:
             return data_field.name, data_field.type
 
     return list(map(as_name_and_type, dataclass_fields.values()))
@@ -365,10 +365,10 @@ def _align_generic_concrete(
     try:
         origin = data_type_with_generics.__origin__
         if issubclass(origin, Sequence):
-            generics = [TypeVar("T")]
+            generics = [TypeVar("T")]  # type: ignore
             values = data_type_with_generics.__args__
         elif issubclass(origin, Mapping):
-            generics = [TypeVar("KT"), TypeVar("VT_co")]
+            generics = [TypeVar("KT"), TypeVar("VT_co")]  # type: ignore
             values = data_type_with_generics.__args__
         else:
             # should be a dataclass

--- a/core_utils/serialization.py
+++ b/core_utils/serialization.py
@@ -188,9 +188,6 @@ def deserialize(
 
     if isinstance(type_value, TypeVar):
         # is a generic type alias: cannot do much with this, so return as-is
-        import ipdb
-
-        ipdb.set_trace()
         return value
 
     checking_type_value: Type = checkable_type(type_value)
@@ -365,11 +362,6 @@ def _dataclass_from_dict(
         try:
             field_and_types = list(_dataclass_field_types(dataclass_type))
         except AttributeError as ae:
-
-            import ipdb
-
-            ipdb.set_trace()
-
             raise TypeError(
                 "Did you pass-in a type that is decorated with @dataclass? "
                 "It needs a .__dataclass_fields__ member to obtain a list of field names "
@@ -377,6 +369,7 @@ def _dataclass_from_dict(
                 f"Type '{type_name(dataclass_type)}' does not work.",
                 ae,
             )
+
         deserialized_fields = _values_for_type(
             field_and_types, data, dataclass_type, custom
         )
@@ -429,41 +422,33 @@ def _fill(generic_to_concrete, generic_type):
 
 def _exec(origin_type, tn):
     module, _ = split_module_value(type_name(origin_type, keep_main=True))
-    try:
-        m_bits = module.split(".")
-        # fmt: off
-        e_str = (
-            f"import typing\n"
-            f"from typing import *\n"
-        )
-        # fmt: on
-        for i in range(1, len(m_bits)):
-            m = ".".join(m_bits[0:i])
-            # fmt: off
-            e_str += (
-                f"import {m}\n"
-                f"from {m} import *\n"
-                f"from {m} import {m_bits[i]}\n"
-            )
-            # fmt: on
-        ____typ = "____typ"
+    m_bits = module.split(".")
+    # fmt: off
+    e_str = (
+        f"import typing\n"
+        f"from typing import *\n"
+    )
+    # fmt: on
+    for i in range(1, len(m_bits)):
+        m = ".".join(m_bits[0:i])
         # fmt: off
         e_str += (
-            f"from {'.'.join(m_bits)} import *\n"
-            f"{____typ} = {tn}"
+            f"import {m}\n"
+            f"from {m} import *\n"
+            f"from {m} import {m_bits[i]}\n"
         )
         # fmt: on
-        namespace = globals().copy()
-        print(e_str)
-        exec(e_str, namespace)
-        typ = namespace[____typ]
-        return typ
-
-    except:
-        import ipdb
-
-        ipdb.set_trace()
-        raise
+    ____typ = "____typ"
+    # fmt: off
+    e_str += (
+        f"from {'.'.join(m_bits)} import *\n"
+        f"{____typ} = {tn}"
+    )
+    # fmt: on
+    namespace = globals().copy()
+    exec(e_str, namespace)
+    typ = namespace[____typ]
+    return typ
 
 
 def _values_for_type(
@@ -515,9 +500,6 @@ def _values_for_type(
         elif _is_optional(field_type):  # type: ignore
             value = None
         else:
-            import ipdb
-
-            ipdb.set_trace()
             raise MissingRequired(
                 field_name=field_name,
                 field_expected_type=field_type,

--- a/core_utils/serialization.py
+++ b/core_utils/serialization.py
@@ -122,10 +122,14 @@ def deserialize(
     if custom is not None and type_value in custom:
         return custom[type_value](value)
 
+    print("TODO - if type name starts with '~' then pass-thru")
     if type_value == Any:
         return value
 
     checking_type_value: Type = checkable_type(type_value)
+
+    if hasattr(type_value, "__origin__"):
+        return deserialize(type_value.__origin__, value)
 
     if is_namedtuple(checking_type_value):
         return _namedtuple_from_dict(type_value, value, custom)

--- a/core_utils/serialization.py
+++ b/core_utils/serialization.py
@@ -327,7 +327,9 @@ def _dataclass_from_dict(
         )
 
 
-def _dataclass_field_types(dataclass_type: Type) -> Iterable[Tuple[str, Type]]:
+def _dataclass_field_types(
+    dataclass_type: Type, generic_to_concrete: Mapping[str, Type]
+) -> Iterable[Tuple[str, Type]]:
     """Obtain the fields & their expected types for the given @dataclass type.
     """
     if hasattr(dataclass_type, "__origin__"):
@@ -336,7 +338,8 @@ def _dataclass_field_types(dataclass_type: Type) -> Iterable[Tuple[str, Type]]:
         dataclass_fields = dataclass_type.__dataclass_fields__  # type: ignore
 
     def as_name_and_type(data_field: Field) -> Tuple[str, Type]:
-        return data_field.name, data_field.type
+        typ = generic_to_concrete.get(str(data_field.type), data_field.type)
+        return data_field.name, typ
 
     return list(map(as_name_and_type, dataclass_fields.values()))
 
@@ -390,6 +393,9 @@ def _values_for_type(
         elif _is_optional(field_type):  # type: ignore
             value = None
         else:
+            import ipdb
+
+            ipdb.set_trace()
             raise MissingRequired(
                 field_name=field_name,
                 field_expected_type=field_type,

--- a/core_utils/serialization.py
+++ b/core_utils/serialization.py
@@ -417,6 +417,9 @@ def _align_generic_concrete(
 ) -> Iterator[Tuple[Type, Type]]:
     """Accepts a datacclass type that has filled-in generics. Returns an iterator that yields
     pairs of (generic type variable name, instantiated type).
+
+    NOTE: If the supplied type derrives from a Sequence or Mapping, then the generics will be
+          handled appropriately. This is the only exception to non-@dataclass deriving types.
     """
     try:
         origin = data_type_with_generics.__origin__

--- a/core_utils/support_for_testing.py
+++ b/core_utils/support_for_testing.py
@@ -15,7 +15,3 @@ class SimpleGeneric(Generic[T]):
 class NestedGeneric(Generic[A, B]):
     v1: SimpleGeneric[A]
     v2: SimpleGeneric[B]
-
-    @property
-    def values(self) -> Tuple[A, B]:
-        return self.v1.value, self.v2.value

--- a/core_utils/support_for_testing.py
+++ b/core_utils/support_for_testing.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+from typing import Generic, TypeVar, Tuple
+
+T = TypeVar("T")
+A = TypeVar("A")
+B = TypeVar("B")
+
+
+@dataclass(frozen=True)
+class SimpleGeneric(Generic[T]):
+    value: T
+
+
+@dataclass(frozen=True)
+class NestedGeneric(Generic[A, B]):
+    v1: SimpleGeneric[A]
+    v2: SimpleGeneric[B]
+
+    @property
+    def values(self) -> Tuple[A, B]:
+        return self.v1.value, self.v2.value

--- a/core_utils/support_for_testing.py
+++ b/core_utils/support_for_testing.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Generic, TypeVar, Tuple
+from typing import Generic, TypeVar
 
 T = TypeVar("T")
 A = TypeVar("A")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ authors = ["Malcolm Greaves <greaves.malcolm@gmail.com>"]
 homepage = "https://github.com/malcolmgreaves/pywise"
 license = "Apache-2.0"
 readme = 'README.md'
+exclude = ['core_utils/support_for_testing.py'] # NEVER INCLUDE THIS FILE (!)
 packages = [
     { include = "core_utils" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pywise"
-version = "0.2.0"
+version = "0.3.0"
 description = "Robust serialization support for NamedTuple & @dataclass data types."
 authors = ["Malcolm Greaves <greaves.malcolm@gmail.com>"]
 homepage = "https://github.com/malcolmgreaves/pywise"

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -56,9 +56,9 @@ def test_type_name():
         (NTX, f"{__T_prefix}test_common.NTX"),
         (DTX, f"{__T_prefix}test_common.DTX"),
         (Union[float, str], "typing.Union[float, str]"),
-        (Optional[int], "typing.Optional[int]"),
+        (Optional[int], "typing.Union[int, NoneType]"),
         (ValueError, "ValueError"),
-        (X, f"{__T_prefix}test_common.X"),
+        (X, f"{__T_prefix}test_common.test_type_name.<locals>.X"),
         (Constrained, f"{__T_prefix}test_common.Constrained"),
         (
             WithTypeParams[float, int, NTX],

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -44,25 +44,28 @@ def test_type_name():
     class X:
         pass
 
+    # _t = "tests."
+    _t = ""
+
     tests = [
         (str, "str"),
         (float, "float"),
         (int, "int"),
         (Path, "pathlib.Path"),
-        (NTX, "tests.test_common.NTX"),
-        (DTX, "tests.test_common.DTX"),
+        (NTX, f"{_t}test_common.NTX"),
+        (DTX, f"{_t}test_common.DTX"),
         (Union[float, str], "typing.Union[float, str]"),
         (Optional[int], "typing.Optional[int]"),
         (ValueError, "ValueError"),
-        (X, "tests.test_common.X"),
-        (Constrained, "tests.test_common.Constrained"),
+        (X, f"{_t}test_common.X"),
+        (Constrained, f"{_t}test_common.Constrained"),
         (
             WithTypeParams[float, int, NTX],
-            "tests.test_common.WithTypeParams[float, int, tests.test_common.NTX]",
+            f"{_t}test_common.WithTypeParams[float, int, {_t}test_common.NTX]",
         ),
         (
             WithTypeParams[float, int, DTX],
-            "tests.test_common.WithTypeParams[float, int, tests.test_common.DTX]",
+            f"{_t}test_common.WithTypeParams[float, int, {_t}test_common.DTX]",
         ),
     ]
     for inp, expected in tests:
@@ -84,7 +87,7 @@ def test_import_by_name():
         l = import_by_name(t)
         assert l == x
 
-    assert Constrained == import_by_name("tests.test_common.Constrained")
+    assert Constrained == import_by_name(f"{_t}test_common.Constrained")
 
     assert typing == import_by_name("typing")
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -40,10 +40,6 @@ class DTX:
     name: str
 
 
-# _t = "tests."
-__T_prefix = ""
-
-
 def test_type_name():
     class X:
         pass
@@ -53,20 +49,20 @@ def test_type_name():
         (float, "float"),
         (int, "int"),
         (Path, "pathlib.Path"),
-        (NTX, f"{__T_prefix}test_common.NTX"),
-        (DTX, f"{__T_prefix}test_common.DTX"),
+        (NTX, "test_common.NTX"),
+        (DTX, "test_common.DTX"),
         (Union[float, str], "typing.Union[float, str]"),
-        (Optional[int], "typing.Union[int, NoneType]"),
+        (Optional[int], "typing.Optional[int]"),
         (ValueError, "ValueError"),
-        (X, f"{__T_prefix}test_common.test_type_name.<locals>.X"),
-        (Constrained, f"{__T_prefix}test_common.Constrained"),
+        (X, "test_common.X"),
+        (Constrained, "test_common.Constrained"),
         (
             WithTypeParams[float, int, NTX],
-            f"{__T_prefix}test_common.WithTypeParams[float, int, {__T_prefix}test_common.NTX]",
+            "test_common.WithTypeParams[float, int, test_common.NTX]",
         ),
         (
             WithTypeParams[float, int, DTX],
-            f"{__T_prefix}test_common.WithTypeParams[float, int, {__T_prefix}test_common.DTX]",
+            "test_common.WithTypeParams[float, int, test_common.DTX]",
         ),
     ]
     for inp, expected in tests:
@@ -88,7 +84,7 @@ def test_import_by_name():
         l = import_by_name(t)
         assert l == x
 
-    assert Constrained == import_by_name(f"{__T_prefix}test_common.Constrained")
+    assert Constrained == import_by_name("test_common.Constrained")
 
     assert typing == import_by_name("typing")
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -40,32 +40,33 @@ class DTX:
     name: str
 
 
+# _t = "tests."
+__T_prefix = ""
+
+
 def test_type_name():
     class X:
         pass
-
-    # _t = "tests."
-    _t = ""
 
     tests = [
         (str, "str"),
         (float, "float"),
         (int, "int"),
         (Path, "pathlib.Path"),
-        (NTX, f"{_t}test_common.NTX"),
-        (DTX, f"{_t}test_common.DTX"),
+        (NTX, f"{__T_prefix}test_common.NTX"),
+        (DTX, f"{__T_prefix}test_common.DTX"),
         (Union[float, str], "typing.Union[float, str]"),
         (Optional[int], "typing.Optional[int]"),
         (ValueError, "ValueError"),
-        (X, f"{_t}test_common.X"),
-        (Constrained, f"{_t}test_common.Constrained"),
+        (X, f"{__T_prefix}test_common.X"),
+        (Constrained, f"{__T_prefix}test_common.Constrained"),
         (
             WithTypeParams[float, int, NTX],
-            f"{_t}test_common.WithTypeParams[float, int, {_t}test_common.NTX]",
+            f"{__T_prefix}test_common.WithTypeParams[float, int, {__T_prefix}test_common.NTX]",
         ),
         (
             WithTypeParams[float, int, DTX],
-            f"{_t}test_common.WithTypeParams[float, int, {_t}test_common.DTX]",
+            f"{__T_prefix}test_common.WithTypeParams[float, int, {__T_prefix}test_common.DTX]",
         ),
     ]
     for inp, expected in tests:
@@ -87,7 +88,7 @@ def test_import_by_name():
         l = import_by_name(t)
         assert l == x
 
-    assert Constrained == import_by_name(f"{_t}test_common.Constrained")
+    assert Constrained == import_by_name(f"{__T_prefix}test_common.Constrained")
 
     assert typing == import_by_name("typing")
 

--- a/tests/test_dataclass_with_generic.py
+++ b/tests/test_dataclass_with_generic.py
@@ -75,3 +75,37 @@ def test_serialize_generic(
     _rt("SimpleGeneric[str]", simple_str)
     _rt("NestedGeneric[int,int]", nested_int_int)
     _rt("NestedGeneric[int, str]", nested_int_str)
+
+
+def test_serialize_generic_complex_nested():
+    x = NestedGeneric[
+        str,
+        NestedGeneric[
+            int, NestedGeneric[float, NestedGeneric[List[int], Mapping[str, int]]],
+        ],
+    ](
+        "i am a str",
+        NestedGeneric[
+            int, NestedGeneric[float, NestedGeneric[List[int], Mapping[str, int]]],
+        ](
+            999,
+            NestedGeneric[float, NestedGeneric[List[int], Mapping[str, int]]](
+                -1.0,
+                NestedGeneric[List[int], Mapping[str, int]](
+                    [0, 2, 4, 6, 8, 10],
+                    {"hello": 0, "how": 78892, "are": -12561, "you?": 463},
+                ),
+            ),
+        ),
+    )
+
+    d = deserialize(
+        NestedGeneric[
+            str,
+            NestedGeneric[
+                int, NestedGeneric[float, NestedGeneric[List[int], Mapping[str, int]]],
+            ],
+        ],
+        x,
+    )
+    assert d == x

--- a/tests/test_dataclass_with_generic.py
+++ b/tests/test_dataclass_with_generic.py
@@ -106,6 +106,6 @@ def test_serialize_generic_complex_nested():
                 int, NestedGeneric[float, NestedGeneric[List[int], Mapping[str, int]]],
             ],
         ],
-        x,
+        serialize(x),
     )
     assert d == x

--- a/tests/test_dataclass_with_generic.py
+++ b/tests/test_dataclass_with_generic.py
@@ -1,7 +1,8 @@
-from dataclasses import dataclass
-from typing import Generic, TypeVar, Tuple, Any, Type, List, Mapping
+from typing import Tuple, Any, Type, List, Mapping
 
 from pytest import fixture
+
+from core_utils.support_for_testing import SimpleGeneric, NestedGeneric
 
 from core_utils.serialization import (
     serialize,
@@ -9,25 +10,6 @@ from core_utils.serialization import (
     _align_generic_concrete_flatten,
     _align_generic_concrete,
 )
-
-T = TypeVar("T")
-A = TypeVar("A")
-B = TypeVar("B")
-
-
-@dataclass(frozen=True)
-class SimpleGeneric(Generic[T]):
-    value: T
-
-
-@dataclass(frozen=True)
-class NestedGeneric(Generic[A, B]):
-    v1: SimpleGeneric[A]
-    v2: SimpleGeneric[B]
-
-    @property
-    def values(self) -> Tuple[A, B]:
-        return self.v1.value, self.v2.value
 
 
 @fixture(scope="module")

--- a/tests/test_dataclass_with_generic.py
+++ b/tests/test_dataclass_with_generic.py
@@ -56,7 +56,7 @@ def _rt(t: str, x: Any) -> None:
 
 
 def _align(x: Tuple[Type, Type], str_name: str, typ: Type) -> None:
-    assert x[0] == f"~{str_name}"
+    assert str(x[0]) == f"~{str_name}"
     assert x[1] == typ
 
 

--- a/tests/test_dataclass_with_generic.py
+++ b/tests/test_dataclass_with_generic.py
@@ -6,8 +6,6 @@ from pytest import fixture
 from core_utils.serialization import (
     serialize,
     deserialize,
-    _align_generic_concrete,
-    _align_generic_concrete_flatten,
 )
 
 T = TypeVar("T")
@@ -58,112 +56,6 @@ def nested_int_int(simple_10, simple_neg_2) -> NestedGeneric[int, int]:
 def _rt(t: str, x: Any) -> None:
     _ = x
     assert eval(f"deserialize({t}, serialize(x)) == x")
-
-
-def _align(x: Tuple[Type, Type], str_name: str, typ: Type) -> None:
-    assert str(x[0]) == f"~{str_name}"
-    assert x[1] == typ
-
-
-def test_align_generic_concrete_one_level():
-    x = list(_align_generic_concrete(SimpleGeneric[int]))
-    assert len(x) == 1
-    _align(x[0], "T", int)
-
-    x = list(_align_generic_concrete(List[bytes]))
-    assert len(x) == 1
-    _align(x[0], "T", bytes)
-
-
-def test_align_generic_concrete_two_level():
-    x = list(_align_generic_concrete(NestedGeneric[str, float]))
-    assert len(x) == 2
-    _align(x[0], "A", str)
-    _align(x[1], "B", float)
-
-    x = list(_align_generic_concrete(Mapping[str, Any]))
-    assert len(x) == 2
-    _align(x[0], "KT", str)
-    _align(x[1], "VT_co", Any)
-
-
-def test_align_generic_concrete_complex_nested():
-    x = list(
-        _align_generic_concrete(
-            NestedGeneric[
-                str,
-                NestedGeneric[
-                    int,
-                    NestedGeneric[float, NestedGeneric[List[int], Mapping[str, int]]],
-                ],
-            ]
-        )
-    )
-    assert len(x) == 2
-    _align(x[0], "A", str)
-    _align(
-        x[1],
-        "B",
-        NestedGeneric[
-            int, NestedGeneric[float, NestedGeneric[List[int], Mapping[str, int]]],
-        ],
-    )
-
-    x = list(_align_generic_concrete(x[1][1]))
-    assert len(x) == 2
-    _align(x[0], "A", int)
-    _align(x[1], "B", NestedGeneric[float, NestedGeneric[List[int], Mapping[str, int]]])
-
-    x = list(_align_generic_concrete(x[1][1]))
-    assert len(x) == 2
-    _align(x[0], "A", float)
-    _align(x[1], "B", NestedGeneric[List[int], Mapping[str, int]])
-
-    x = list(_align_generic_concrete(x[1][1]))
-    assert len(x) == 2
-    _align(x[0], "A", List[int])
-    _align(x[1], "B", Mapping[str, int])
-
-    x_list = list(_align_generic_concrete(x[0][1]))
-    assert len(x_list) == 1
-    _align(x_list[0], "T", int)
-
-    x_map = list(_align_generic_concrete(x[1][1]))
-    assert len(x_map) == 2
-    _align(x_map[0], "KT", str)
-    _align(x_map[1], "VT_co", int)
-
-
-def test_align_generic_concrete_flatten():
-    x = list(
-        _align_generic_concrete_flatten(
-            NestedGeneric[
-                str,
-                NestedGeneric[
-                    int,
-                    NestedGeneric[float, NestedGeneric[List[int], Mapping[str, int]]],
-                ],
-            ]
-        )
-    )
-    assert len(x) == 11
-    _align(x[0], "A", str)
-    _align(
-        x[1],
-        "B",
-        NestedGeneric[
-            int, NestedGeneric[float, NestedGeneric[List[int], Mapping[str, int]]]
-        ],
-    )
-    _align(x[2], "A", int)
-    _align(x[3], "B", NestedGeneric[float, NestedGeneric[List[int], Mapping[str, int]]])
-    _align(x[4], "A", float)
-    _align(x[5], "B", NestedGeneric[List[int], Mapping[str, int]])
-    _align(x[6], "A", List[int])
-    _align(x[7], "T", int)
-    _align(x[8], "B", Mapping[str, int])
-    _align(x[9], "KT", str)
-    _align(x[10], "VT_co", int)
 
 
 def test_serialize_non_generic(

--- a/tests/test_dataclass_with_generic.py
+++ b/tests/test_dataclass_with_generic.py
@@ -3,7 +3,12 @@ from typing import Generic, TypeVar, Tuple, Any, Type, List, Mapping
 
 from pytest import fixture
 
-from core_utils.serialization import serialize, deserialize, _align_generic_concrete
+from core_utils.serialization import (
+    serialize,
+    deserialize,
+    _align_generic_concrete,
+    _align_generic_concrete_flatten,
+)
 
 T = TypeVar("T")
 A = TypeVar("A")
@@ -127,6 +132,38 @@ def test_align_generic_concrete_complex_nested():
     assert len(x_map) == 2
     _align(x_map[0], "KT", str)
     _align(x_map[1], "VT_co", int)
+
+
+def test_align_generic_concrete_flatten():
+    x = list(
+        _align_generic_concrete_flatten(
+            NestedGeneric[
+                str,
+                NestedGeneric[
+                    int,
+                    NestedGeneric[float, NestedGeneric[List[int], Mapping[str, int]]],
+                ],
+            ]
+        )
+    )
+    assert len(x) == 11
+    _align(x[0], "A", str)
+    _align(
+        x[1],
+        "B",
+        NestedGeneric[
+            int, NestedGeneric[float, NestedGeneric[List[int], Mapping[str, int]]]
+        ],
+    )
+    _align(x[2], "A", int)
+    _align(x[3], "B", NestedGeneric[float, NestedGeneric[List[int], Mapping[str, int]]])
+    _align(x[4], "A", float)
+    _align(x[5], "B", NestedGeneric[List[int], Mapping[str, int]])
+    _align(x[6], "A", List[int])
+    _align(x[7], "T", int)
+    _align(x[8], "B", Mapping[str, int])
+    _align(x[9], "KT", str)
+    _align(x[10], "VT_co", int)
 
 
 def test_serialize_non_generic(

--- a/tests/test_dataclass_with_generic.py
+++ b/tests/test_dataclass_with_generic.py
@@ -1,9 +1,9 @@
 from dataclasses import dataclass
-from typing import Generic, TypeVar, Tuple, Any
+from typing import Generic, TypeVar, Tuple, Any, Type, List, Mapping
 
 from pytest import fixture
 
-from core_utils.serialization import serialize, deserialize
+from core_utils.serialization import serialize, deserialize, _align_generic_concrete
 
 T = TypeVar("T")
 A = TypeVar("A")
@@ -53,6 +53,59 @@ def nested_int_int(simple_10, simple_neg_2) -> NestedGeneric[int, int]:
 def _rt(t: str, x: Any) -> None:
     _ = x
     assert eval(f"deserialize({t}, serialize(x)) == x")
+
+
+def _align(x: Tuple[Type, Type], str_name: str, typ: Type) -> None:
+    assert x[0] == f"~{str_name}"
+    assert x[1] == typ
+
+
+def test_align_generic_concrete_one_level():
+    x = list(_align_generic_concrete(SimpleGeneric[int]))
+    assert len(x) == 1
+    _align(x[0], "T", int)
+
+    x = list(_align_generic_concrete(List[bytes]))
+    assert len(x) == 1
+    _align(x[0], "T", bytes)
+
+
+def test_align_generic_concrete_two_level():
+    x = list(_align_generic_concrete(NestedGeneric[str, float]))
+    assert len(x) == 2
+    _align(x[0], "A", str)
+    _align(x[1], "B", float)
+
+    x = list(_align_generic_concrete(Mapping[str, Any]))
+    assert len(x) == 2
+    _align(x[0], "KT", str)
+    _align(x[1], "VT_co", Any)
+
+
+def test_align_generic_concrete_complex_nested():
+    x = list(
+        _align_generic_concrete(
+            NestedGeneric[
+                str,
+                NestedGeneric[
+                    int,
+                    NestedGeneric[float, NestedGeneric[List[int], Mapping[str, int]]],
+                ],
+            ]
+        )
+    )
+    assert len(x) == 11
+    _align(x[0], "A", str)
+    _align(x[1], "B", NestedGeneric)
+    _align(x[2], "KT", str)
+    _align(x[3], "VT_co", Any)
+    _align(x[4], "KT", str)
+    _align(x[5], "VT_co", Any)
+    _align(x[6], "KT", str)
+    _align(x[7], "VT_co", Any)
+    _align(x[8], "KT", str)
+    _align(x[9], "VT_co", Any)
+    _align(x[10], "KT", str)
 
 
 def test_serialize_non_generic(

--- a/tests/test_dataclass_with_generic.py
+++ b/tests/test_dataclass_with_generic.py
@@ -69,19 +69,29 @@ def test_serialize_generic_complex_nested():
         ],
     ](
         SimpleGeneric[str]("i am a str"),
-        NestedGeneric[
-            int, NestedGeneric[float, NestedGeneric[List[int], Mapping[str, int]]],
+        SimpleGeneric[
+            NestedGeneric[
+                int, NestedGeneric[float, NestedGeneric[List[int], Mapping[str, int]]],
+            ]
         ](
-            SimpleGeneric[int](999),
-            NestedGeneric[float, NestedGeneric[List[int], Mapping[str, int]]](
-                SimpleGeneric[float](-1.0),
-                NestedGeneric[List[int], Mapping[str, int]](
-                    SimpleGeneric[List[int]]([0, 2, 4, 6, 8, 10]),
-                    SimpleGeneric[Mapping[str, int]](
-                        {"hello": 0, "how": 78892, "are": -12561, "you?": 463},
+            NestedGeneric[
+                int, NestedGeneric[float, NestedGeneric[List[int], Mapping[str, int]]]
+            ](
+                SimpleGeneric[int](999),
+                SimpleGeneric[
+                    NestedGeneric[float, NestedGeneric[List[int], Mapping[str, int]]]
+                ](
+                    SimpleGeneric[float](-1.0),
+                    SimpleGeneric[NestedGeneric[List[int], Mapping[str, int]]](
+                        NestedGeneric[List[int], Mapping[str, int]](
+                            SimpleGeneric[List[int]]([0, 2, 4, 6, 8, 10]),
+                            SimpleGeneric[Mapping[str, int]](
+                                {"hello": 0, "how": 78892, "are": -12561, "you?": 463},
+                            ),
+                        )
                     ),
                 ),
-            ),
+            )
         ),
     )
 

--- a/tests/test_dataclass_with_generic.py
+++ b/tests/test_dataclass_with_generic.py
@@ -68,28 +68,37 @@ def test_serialize_generic_complex_nested():
             int, NestedGeneric[float, NestedGeneric[List[int], Mapping[str, int]]],
         ],
     ](
-        SimpleGeneric[str]("i am a str"),
+        SimpleGeneric[str](value="i am a str"),
         SimpleGeneric[
             NestedGeneric[
                 int, NestedGeneric[float, NestedGeneric[List[int], Mapping[str, int]]],
             ]
         ](
-            NestedGeneric[
+            value=NestedGeneric[
                 int, NestedGeneric[float, NestedGeneric[List[int], Mapping[str, int]]]
             ](
-                SimpleGeneric[int](999),
-                SimpleGeneric[
+                v1=SimpleGeneric[int](value=999),
+                v2=SimpleGeneric[
                     NestedGeneric[float, NestedGeneric[List[int], Mapping[str, int]]]
                 ](
-                    SimpleGeneric[float](-1.0),
-                    SimpleGeneric[NestedGeneric[List[int], Mapping[str, int]]](
-                        NestedGeneric[List[int], Mapping[str, int]](
-                            SimpleGeneric[List[int]]([0, 2, 4, 6, 8, 10]),
-                            SimpleGeneric[Mapping[str, int]](
-                                {"hello": 0, "how": 78892, "are": -12561, "you?": 463},
-                            ),
-                        )
-                    ),
+                    value=NestedGeneric[
+                        float, NestedGeneric[List[int], Mapping[str, int]]
+                    ](
+                        v1=SimpleGeneric[float](value=-1.0),
+                        v2=SimpleGeneric[NestedGeneric[List[int], Mapping[str, int]]](
+                            value=NestedGeneric[List[int], Mapping[str, int]](
+                                v1=SimpleGeneric[List[int]](value=[0, 2, 4, 6, 8, 10],),
+                                v2=SimpleGeneric[Mapping[str, int]](
+                                    value={
+                                        "hello": 0,
+                                        "how": 78892,
+                                        "are": -12561,
+                                        "you?": 463,
+                                    },
+                                ),
+                            )
+                        ),
+                    )
                 ),
             )
         ),

--- a/tests/test_dataclass_with_generic.py
+++ b/tests/test_dataclass_with_generic.py
@@ -6,6 +6,8 @@ from pytest import fixture
 from core_utils.serialization import (
     serialize,
     deserialize,
+    _align_generic_concrete_flatten,
+    _align_generic_concrete,
 )
 
 T = TypeVar("T")
@@ -109,3 +111,109 @@ def test_serialize_generic_complex_nested():
         serialize(x),
     )
     assert d == x
+
+
+def _align(x: Tuple[Type, Type], str_name: str, typ: Type) -> None:
+    assert str(x[0]) == f"~{str_name}"
+    assert x[1] == typ
+
+
+def test_align_generic_concrete_one_level():
+    x = list(_align_generic_concrete(SimpleGeneric[int]))
+    assert len(x) == 1
+    _align(x[0], "T", int)
+
+    x = list(_align_generic_concrete(List[bytes]))
+    assert len(x) == 1
+    _align(x[0], "T", bytes)
+
+
+def test_align_generic_concrete_two_level():
+    x = list(_align_generic_concrete(NestedGeneric[str, float]))
+    assert len(x) == 2
+    _align(x[0], "A", str)
+    _align(x[1], "B", float)
+
+    x = list(_align_generic_concrete(Mapping[str, Any]))
+    assert len(x) == 2
+    _align(x[0], "KT", str)
+    _align(x[1], "VT_co", Any)
+
+
+def test_align_generic_concrete_complex_nested():
+    x = list(
+        _align_generic_concrete(
+            NestedGeneric[
+                str,
+                NestedGeneric[
+                    int,
+                    NestedGeneric[float, NestedGeneric[List[int], Mapping[str, int]]],
+                ],
+            ]
+        )
+    )
+    assert len(x) == 2
+    _align(x[0], "A", str)
+    _align(
+        x[1],
+        "B",
+        NestedGeneric[
+            int, NestedGeneric[float, NestedGeneric[List[int], Mapping[str, int]]],
+        ],
+    )
+
+    x = list(_align_generic_concrete(x[1][1]))
+    assert len(x) == 2
+    _align(x[0], "A", int)
+    _align(x[1], "B", NestedGeneric[float, NestedGeneric[List[int], Mapping[str, int]]])
+
+    x = list(_align_generic_concrete(x[1][1]))
+    assert len(x) == 2
+    _align(x[0], "A", float)
+    _align(x[1], "B", NestedGeneric[List[int], Mapping[str, int]])
+
+    x = list(_align_generic_concrete(x[1][1]))
+    assert len(x) == 2
+    _align(x[0], "A", List[int])
+    _align(x[1], "B", Mapping[str, int])
+
+    x_list = list(_align_generic_concrete(x[0][1]))
+    assert len(x_list) == 1
+    _align(x_list[0], "T", int)
+
+    x_map = list(_align_generic_concrete(x[1][1]))
+    assert len(x_map) == 2
+    _align(x_map[0], "KT", str)
+    _align(x_map[1], "VT_co", int)
+
+
+def test_align_generic_concrete_flatten():
+    x = list(
+        _align_generic_concrete_flatten(
+            NestedGeneric[
+                str,
+                NestedGeneric[
+                    int,
+                    NestedGeneric[float, NestedGeneric[List[int], Mapping[str, int]]],
+                ],
+            ]
+        )
+    )
+    assert len(x) == 11
+    _align(x[0], "A", str)
+    _align(
+        x[1],
+        "B",
+        NestedGeneric[
+            int, NestedGeneric[float, NestedGeneric[List[int], Mapping[str, int]]]
+        ],
+    )
+    _align(x[2], "A", int)
+    _align(x[3], "B", NestedGeneric[float, NestedGeneric[List[int], Mapping[str, int]]])
+    _align(x[4], "A", float)
+    _align(x[5], "B", NestedGeneric[List[int], Mapping[str, int]])
+    _align(x[6], "A", List[int])
+    _align(x[7], "T", int)
+    _align(x[8], "B", Mapping[str, int])
+    _align(x[9], "KT", str)
+    _align(x[10], "VT_co", int)

--- a/tests/test_dataclass_with_generic.py
+++ b/tests/test_dataclass_with_generic.py
@@ -94,18 +94,39 @@ def test_align_generic_concrete_complex_nested():
             ]
         )
     )
-    assert len(x) == 11
+    assert len(x) == 2
     _align(x[0], "A", str)
-    _align(x[1], "B", NestedGeneric)
-    _align(x[2], "KT", str)
-    _align(x[3], "VT_co", Any)
-    _align(x[4], "KT", str)
-    _align(x[5], "VT_co", Any)
-    _align(x[6], "KT", str)
-    _align(x[7], "VT_co", Any)
-    _align(x[8], "KT", str)
-    _align(x[9], "VT_co", Any)
-    _align(x[10], "KT", str)
+    _align(
+        x[1],
+        "B",
+        NestedGeneric[
+            int, NestedGeneric[float, NestedGeneric[List[int], Mapping[str, int]]],
+        ],
+    )
+
+    x = list(_align_generic_concrete(x[1][1]))
+    assert len(x) == 2
+    _align(x[0], "A", int)
+    _align(x[1], "B", NestedGeneric[float, NestedGeneric[List[int], Mapping[str, int]]])
+
+    x = list(_align_generic_concrete(x[1][1]))
+    assert len(x) == 2
+    _align(x[0], "A", float)
+    _align(x[1], "B", NestedGeneric[List[int], Mapping[str, int]])
+
+    x = list(_align_generic_concrete(x[1][1]))
+    assert len(x) == 2
+    _align(x[0], "A", List[int])
+    _align(x[1], "B", Mapping[str, int])
+
+    x_list = list(_align_generic_concrete(x[0][1]))
+    assert len(x_list) == 1
+    _align(x_list[0], "T", int)
+
+    x_map = list(_align_generic_concrete(x[1][1]))
+    assert len(x_map) == 2
+    _align(x_map[0], "KT", str)
+    _align(x_map[1], "VT_co", int)
 
 
 def test_serialize_non_generic(

--- a/tests/test_dataclass_with_generic.py
+++ b/tests/test_dataclass_with_generic.py
@@ -7,7 +7,6 @@ from core_utils.support_for_testing import SimpleGeneric, NestedGeneric
 from core_utils.serialization import (
     serialize,
     deserialize,
-    _align_generic_concrete_flatten,
     _align_generic_concrete,
 )
 
@@ -188,35 +187,3 @@ def test_align_generic_concrete_complex_nested():
     assert len(x_map) == 2
     _align(x_map[0], "KT", str)
     _align(x_map[1], "VT_co", int)
-
-
-def test_align_generic_concrete_flatten():
-    x = list(
-        _align_generic_concrete_flatten(
-            NestedGeneric[
-                str,
-                NestedGeneric[
-                    int,
-                    NestedGeneric[float, NestedGeneric[List[int], Mapping[str, int]]],
-                ],
-            ]
-        )
-    )
-    assert len(x) == 11
-    _align(x[0], "A", str)
-    _align(
-        x[1],
-        "B",
-        NestedGeneric[
-            int, NestedGeneric[float, NestedGeneric[List[int], Mapping[str, int]]]
-        ],
-    )
-    _align(x[2], "A", int)
-    _align(x[3], "B", NestedGeneric[float, NestedGeneric[List[int], Mapping[str, int]]])
-    _align(x[4], "A", float)
-    _align(x[5], "B", NestedGeneric[List[int], Mapping[str, int]])
-    _align(x[6], "A", List[int])
-    _align(x[7], "T", int)
-    _align(x[8], "B", Mapping[str, int])
-    _align(x[9], "KT", str)
-    _align(x[10], "VT_co", int)

--- a/tests/test_dataclass_with_generic.py
+++ b/tests/test_dataclass_with_generic.py
@@ -1,0 +1,74 @@
+from dataclasses import dataclass
+from typing import Generic, TypeVar, Tuple, Any
+
+from pytest import fixture
+
+from core_utils.serialization import serialize, deserialize
+
+T = TypeVar("T")
+A = TypeVar("A")
+B = TypeVar("B")
+
+
+@dataclass(frozen=True)
+class SimpleGeneric(Generic[T]):
+    value: T
+
+
+@dataclass(frozen=True)
+class NestedGeneric(Generic[A, B]):
+    v1: SimpleGeneric[A]
+    v2: SimpleGeneric[B]
+
+    @property
+    def values(self) -> Tuple[A, B]:
+        return self.v1.value, self.v2.value
+
+
+@fixture(scope="module")
+def simple_10() -> SimpleGeneric[int]:
+    return SimpleGeneric(10)
+
+
+@fixture(scope="module")
+def simple_neg_2() -> SimpleGeneric[int]:
+    return SimpleGeneric(-2)
+
+
+@fixture(scope="module")
+def simple_str() -> SimpleGeneric[str]:
+    return SimpleGeneric("Hello world!")
+
+
+@fixture(scope="module")
+def nested_int_str(simple_10, simple_str) -> NestedGeneric[int, str]:
+    return NestedGeneric(simple_10, simple_str)
+
+
+@fixture(scope="module")
+def nested_int_int(simple_10, simple_neg_2) -> NestedGeneric[int, int]:
+    return NestedGeneric(simple_10, simple_neg_2)
+
+
+def _rt(t: str, x: Any) -> None:
+    _ = x
+    assert eval(f"deserialize({t}, serialize(x)) == x")
+
+
+def test_serialize_non_generic(
+    simple_10, simple_neg_2, simple_str, nested_int_int, nested_int_str
+):
+    for s in [simple_10, simple_neg_2, simple_str]:
+        assert deserialize(SimpleGeneric, serialize(s)) == s
+    for n in [nested_int_int, nested_int_str]:
+        assert deserialize(NestedGeneric, serialize(n)) == n
+
+
+def test_serialize_generic(
+    simple_10, simple_neg_2, simple_str, nested_int_int, nested_int_str
+):
+    for s in [simple_10, simple_neg_2]:
+        _rt("SimpleGeneric[int]", s)
+    _rt("SimpleGeneric[str]", simple_str)
+    _rt("NestedGeneric[int,int]", nested_int_int)
+    _rt("NestedGeneric[int, str]", nested_int_str)

--- a/tests/test_dataclass_with_generic.py
+++ b/tests/test_dataclass_with_generic.py
@@ -86,16 +86,18 @@ def test_serialize_generic_complex_nested():
             int, NestedGeneric[float, NestedGeneric[List[int], Mapping[str, int]]],
         ],
     ](
-        "i am a str",
+        SimpleGeneric[str]("i am a str"),
         NestedGeneric[
             int, NestedGeneric[float, NestedGeneric[List[int], Mapping[str, int]]],
         ](
-            999,
+            SimpleGeneric[int](999),
             NestedGeneric[float, NestedGeneric[List[int], Mapping[str, int]]](
-                -1.0,
+                SimpleGeneric[float](-1.0),
                 NestedGeneric[List[int], Mapping[str, int]](
-                    [0, 2, 4, 6, 8, 10],
-                    {"hello": 0, "how": 78892, "are": -12561, "you?": 463},
+                    SimpleGeneric[List[int]]([0, 2, 4, 6, 8, 10]),
+                    SimpleGeneric[Mapping[str, int]](
+                        {"hello": 0, "how": 78892, "are": -12561, "you?": 463},
+                    ),
                 ),
             ),
         ),

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -44,7 +44,7 @@ def _test_more_complex_dict_type_representation(t):
 
 
 def _test_with_optional_dict_type_representation(t):
-    expected = {"level": "int", "maybe": "typing.Optional[int]"}
+    expected = {"level": "int", "maybe": "typing.Union[int, NoneType]"}
     assert dict_type_representation(t) == expected
 
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -44,7 +44,7 @@ def _test_more_complex_dict_type_representation(t):
 
 
 def _test_with_optional_dict_type_representation(t):
-    expected = {"level": "int", "maybe": "typing.Union[int, NoneType]"}
+    expected = {"level": "int", "maybe": "typing.Optional[int]"}
     assert dict_type_representation(t) == expected
 
 


### PR DESCRIPTION
Upgrades `deserialize` (and `serialize`) to handle @dataclass types parameterized with generics. Under the hood, the new `_align_generic_concrete`, `_fill`, and `_exec` functions in the `serialization` module handle reifying the parameterized type information at runtime. These new functions modify `_dataclass_field_types` to properly support "filling-in" the generic "holes" and output fully specified types. Extensive tests have been added to explicitly test deserialization from generic @dataclass types, including a very deeply nested example.

Note that it's not possible to support generics in `NamedTuple` deriving types. I.e. if given `class X(NamedTuple,Generic[T]):...` then `X[int]` is an invalid expression in Python. Since such expressions cannot be used, it's not possible to parametrize the generic types and thus it is not possible to gather reified type information at runtime.

This is a major API change: pre `1.x.x` rules dictate a minor version bump to `0.3.0`.