### PR TITLE
Bugfix deserialize when no generics are present

### DIFF
--- a/core_utils/common.py
+++ b/core_utils/common.py
@@ -14,6 +14,9 @@ def type_name(t: type, keep_main: bool = True) -> str:
     if mod == "builtins":
         return t.__name__
 
+    if t is Any:
+        return "typing.Any"
+
     if str(t).startswith("typing.Union"):
         try:
             args = t.__args__  # type: ignore

--- a/core_utils/serialization.py
+++ b/core_utils/serialization.py
@@ -337,9 +337,11 @@ def _dataclass_field_types(dataclass_type: Type) -> Iterable[Tuple[str, Type]]:
         def as_name_and_type(data_field: Field) -> Tuple[str, Type]:
             if data_field.type in generic_to_concrete:
                 typ = generic_to_concrete[data_field.type]
-            else:
+            elif hasattr(data_field.type, "__parameters__"):
                 tn = _fill(generic_to_concrete, data_field.type)
                 typ = _exec(data_field.type.__origin__, tn)
+            else:
+                typ = data_field.type
             return data_field.name, typ
 
     else:

--- a/core_utils/support_for_testing.py
+++ b/core_utils/support_for_testing.py
@@ -34,6 +34,7 @@ class SimpleNoGen(Generic[T]):
 
 @dataclass(frozen=True)
 class NestedNoGen(Generic[T, A, B]):
-    mo: SimpleNoGen[T]
-    larry: SimpleNoGen[A]
-    curly: SimpleNoGen[B]
+    group_name: str
+    a: SimpleNoGen[T]
+    b: SimpleNoGen[A]
+    c: SimpleNoGen[B]

--- a/core_utils/support_for_testing.py
+++ b/core_utils/support_for_testing.py
@@ -1,3 +1,12 @@
+"""THIS MODULE WILL *NEVER* BE PUBLISHED.
+
+It exists to provide @dataclass definitions to test parameterized generic deserialization.
+Classes cannot be defined in the `test/` directory and be used by `deserialize`:
+they are not in a defined package and thus will not be available in the environment.
+
+The workaround is to define them here and then, in pyproject.toml, ensure that this file
+is excluded from the build process.
+"""
 from dataclasses import dataclass
 from typing import Generic, TypeVar
 
@@ -15,3 +24,15 @@ class SimpleGeneric(Generic[T]):
 class NestedGeneric(Generic[A, B]):
     v1: SimpleGeneric[A]
     v2: SimpleGeneric[B]
+
+
+@dataclass(frozen=True)
+class SimpleNoGen(Generic[T]):
+    age: int
+    name: str
+
+@dataclass(frozen=True)
+class NestedNoGen(Generic[T,A,B]):
+    mo: SimpleNoGen[T]
+    larry: SimpleNoGen[A]
+    curly: SimpleNoGen[B]

--- a/core_utils/support_for_testing.py
+++ b/core_utils/support_for_testing.py
@@ -31,8 +31,9 @@ class SimpleNoGen(Generic[T]):
     age: int
     name: str
 
+
 @dataclass(frozen=True)
-class NestedNoGen(Generic[T,A,B]):
+class NestedNoGen(Generic[T, A, B]):
     mo: SimpleNoGen[T]
     larry: SimpleNoGen[A]
     curly: SimpleNoGen[B]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pywise"
-version = "0.3.0"
+version = "0.3.1"
 description = "Robust serialization support for NamedTuple & @dataclass data types."
 authors = ["Malcolm Greaves <greaves.malcolm@gmail.com>"]
 homepage = "https://github.com/malcolmgreaves/pywise"

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -45,6 +45,7 @@ def test_type_name():
         pass
 
     tests = [
+        (typing.Any, "typing.Any"),
         (str, "str"),
         (float, "float"),
         (int, "int"),

--- a/tests/test_dataclass_with_generic.py
+++ b/tests/test_dataclass_with_generic.py
@@ -2,7 +2,7 @@ from typing import Tuple, Any, Type, List, Mapping
 
 from pytest import fixture
 
-from core_utils.support_for_testing import SimpleGeneric, NestedGeneric
+from core_utils.support_for_testing import SimpleGeneric, NestedGeneric, SimpleNoGen
 
 from core_utils.serialization import (
     serialize,
@@ -187,3 +187,9 @@ def test_align_generic_concrete_complex_nested():
     assert len(x_map) == 2
     _align(x_map[0], "KT", str)
     _align(x_map[1], "VT_co", int)
+
+
+def test_generic_wo_holes():
+    x = SimpleNoGen[float](10, "hello")
+    assert deserialize(SimpleNoGen[float], serialize(x)) == x
+    assert deserialize(SimpleNoGen, serialize(x)) == x

--- a/tests/test_dataclass_with_generic.py
+++ b/tests/test_dataclass_with_generic.py
@@ -201,9 +201,10 @@ def test_generic_wo_holes():
     assert deserialize(SimpleNoGen[Any], serialize(x)) == x
 
     x = NestedNoGen[bytes, type, list](
-        mo=SimpleNoGen[bytes](age=109, name="Mo"),
-        larry=SimpleNoGen[bytes](age=42, name="Larry"),
-        curly=SimpleNoGen[bytes](age=-6, name="Curly"),
+        group_name="The Three Stooges",
+        a=SimpleNoGen[bytes](age=109, name="Mo"),
+        b=SimpleNoGen[bytes](age=42, name="Larry"),
+        c=SimpleNoGen[bytes](age=-6, name="Curly"),
     )
     assert deserialize(NestedNoGen[bytes, type, list], serialize(x)) == x
     assert deserialize(NestedNoGen, serialize(x)) == x

--- a/tests/test_dataclass_with_generic.py
+++ b/tests/test_dataclass_with_generic.py
@@ -2,7 +2,12 @@ from typing import Tuple, Any, Type, List, Mapping
 
 from pytest import fixture
 
-from core_utils.support_for_testing import SimpleGeneric, NestedGeneric, SimpleNoGen
+from core_utils.support_for_testing import (
+    SimpleGeneric,
+    NestedGeneric,
+    SimpleNoGen,
+    NestedNoGen,
+)
 
 from core_utils.serialization import (
     serialize,
@@ -193,3 +198,13 @@ def test_generic_wo_holes():
     x = SimpleNoGen[float](10, "hello")
     assert deserialize(SimpleNoGen[float], serialize(x)) == x
     assert deserialize(SimpleNoGen, serialize(x)) == x
+    assert deserialize(SimpleNoGen[Any], serialize(x)) == x
+
+    x = NestedNoGen[bytes, type, list](
+        mo=SimpleNoGen[bytes](age=109, name="Mo"),
+        larry=SimpleNoGen[bytes](age=42, name="Larry"),
+        curly=SimpleNoGen[bytes](age=-6, name="Curly"),
+    )
+    assert deserialize(NestedNoGen[bytes, type, list], serialize(x)) == x
+    assert deserialize(NestedNoGen, serialize(x)) == x
+    assert deserialize(NestedNoGen[Any, Any, Any], serialize(x)) == x


### PR DESCRIPTION
The deserialize update from version `0.3.0` had a bug where a @dataclass with parameterized types that _did not have any fields using the generic types_ would fail deserialization. This bug was introduced due to an assumption that all non-leaf nodes of the generic @dataclass type's AST would have at least one parameterized generic. The `_dataclass_field_types` function in the `serialization` module has been updated to account for this (rather common) case. New tests have been added to cover this functionality.

Additionally, the `type_name` function in the `common` module has been updated to properly handle `typing.Any`, since it has a unique `_SpecialForm` backing. A new test case has been added to address `Any`.

Version `0.3.1`.