### PR TITLE
Add env var context manager: with Environment

### DIFF
--- a/core_utils/env.py
+++ b/core_utils/env.py
@@ -1,0 +1,178 @@
+import os
+from typing import Any, ContextManager, Dict, Optional, Sequence
+
+__all__: Sequence[str] = ("Environment",)
+
+
+class Environment(ContextManager):
+    """Context manager for temporarily setting environment variables.
+
+     This context manager sets specific environment variables when in use. When entering a context,
+     this class will record the previous values for all of the env vars that it will set. Upon exit,
+     this class restores all previous values to the environment variables that it changed during
+     the context. Variables that were unset before entering the context with :class:`Environment`
+     will be unset when the context is exited.
+
+     **WARNING**: Mutates the `os.environ` environment variable mapping in the :func:`__enter__`
+                  and :func:`__exit__` methods. Every `__enter__` **MUST** be followed-up by an `__exit__`.
+
+     The suggested use pattern is to make a new :class:`Environment` for each scope where one
+    requires temporarily setting environment variables. This common use case looks like:
+     >>> with Environment(ENV_VAR='your-value'):
+     >>>     # do something that needs this ENV_VAR set to 'your-value'
+     >>>     ...
+     >>> # Environment variable "ENV_VAR" is reset to its prior value.
+     >>> # If there was not a previously set value for "ENV_VAR", then it is unset now.
+
+     You can also use `environment` to temporarily ensure that an environment variable is not set:
+     >>>> with Environment(ENV_VAR=None):
+     >>>>   # There is no longer any Environment variable value for "ENV_VAR"
+     >>>>   ...
+     >>>> # If there was one beforehand, the Environment variable "ENV_VAR" is reset.
+     >>>> # Otherwise, it is still unset.
+
+     However, it is possible, however to create one :class:`Environment` instance and re-use to
+     temporarily reset the same declared environment variable state. This use case looks like:
+     >>>> os.environ['ENV_VAR'] = 'first value'
+     >>>> setter = Environment(ENV_VAR='new value')
+     >>>> with setter:
+     >>>>    # ENV_VAR is now set to 'new value'
+     >>>> # ENV_VAR is restored: it is set to 'first value'
+     >>>> os.environ['ENV_VAR'] = 'second value'
+     >>>> setter.set()
+     >>>> # ENV_VAR is now set to 'new value' again
+     >>>> setter.unset()
+     >>>> # ENV_VAR is now restored: it is set to 'second value'
+    """
+
+    def __init__(self, **env_vars) -> None:
+        """Initializes the manager with new environemnt variable values to use during the context.
+
+         NOTE: All environment variables must be string (`str`) valued or `None`.
+               Simple primitive values -- `float`, `int`, `bytes`, `bool` -- will be coerced into
+               a `str` value in the constructor. Any value of another type will result in a
+               `ValueError` being raised.
+
+         Note that supplying `None` means that the environment variable will not be present.
+         That is, it will be deleted from the mapping `os.environ` during the context.
+
+         This is different than setting the environment variable to the empty string (`""`).
+         Using `X=None` means that `"X" in os.environ` will be `False`. Whereas, using `X=""`
+         means that `"X" in os.environ` will be `True`.
+
+        The constructor allows for specifying env vars as keyword arguments:
+        >>>> Environment(ENV_VAR_1='...', ENV_VAR_2='...', ENV_VAR_K='...')
+
+        It is also possible to supply these via a dictionary:
+        >>>> envars: Dict[str, str] = {"ENV_VAR_1": '...', "ENV_VAR_2": '...', "ENV_VAR_K": '...'}
+        >>>> Environment(**envars)
+
+        However, if any key i.e. environment variable name is empty, or not a string (`str`), then
+        this constructor will raise a `ValueError`.
+
+
+        ERRORS:
+              - Raises :class:`ValueError` if:
+                 - the environment variable name is not a non-empty string
+                 - the value is not None or a string (or a value that can be automatically coerced
+                                                      into a string)
+
+        """
+        # used in __enter__ and __exit__: keeps track of prior existing Environment
+        # variable settings s.t. they can be reset when the context block is finished
+        self.__prior_env_var_setting: Dict[str, Optional[str]] = dict()
+
+        # we store the user's set of desired temporary values for Environment variables
+        # we also validate these settings to a minimum bar of correctness
+        self.__new_env_var_settings: Dict[str, Optional[str]] = {
+            env_var: _check_env_var_setting(env_var, value) for env_var, value in env_vars.items()
+        }
+
+    def __enter__(self) -> "Environment":
+        """Grabs the current in-environment values and sets the variables to their supplied values.
+
+        The context-entering step. This method grabs all of the current in-environment values for
+        all supplied variables. This grabs the exact values inside `os.environ`.
+
+        Then, this method sets each of these variables to the values that were supplied at
+        construction time.
+
+        WARNING: Mutates internal state!
+        """
+        # get the existing values for all of the to-be-set env vars before setting them
+        for env, val in self.__new_env_var_settings.items():
+            # track prior value and set new for Environment variable
+            prior: Optional[str] = os.environ.get(env)
+            # note that we're using None to indicate that the env var should be unset on __exit__
+            self.__prior_env_var_setting[env] = prior
+            if val is not None:
+                # we're setting a new value for the environment variable
+                os.environ[env] = val
+            elif env in os.environ:
+                # otherwise, if env=None, then we want to remove this variable from the environment
+                del os.environ[env]
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """Restores the previous values of all overridden environment variables.
+
+        Using the values captured in `__enter__`, this context-exiting method will restore
+        all overriden environment variables to their previous values. If any environment variable
+        that was set during the context did not have a previous value before the managed context,
+        then it is unset. As in, it won't appear in `os.environ` once this method finishes.
+
+        NOTE: This method ignores all input arguments.
+
+        WARNING: Mutates internal state!
+        """
+        # restore all env vars
+        for env, prior in self.__prior_env_var_setting.items():
+            # If there _was_ a prior value, we'll always set it here. This is the same if
+            # we were setting it to some other string or if we wanted the env var
+            # temporarily gone (env=None in the __init__).
+            if prior is not None:
+                # restore previous Environment variable value
+                os.environ[env] = prior
+            else:
+                # If there was no prior value for the env var, then we need to determine
+                # if we had set it to something new in the context. Or, if the env var
+                # didn't exist in the first place.
+                if env in os.environ:
+                    # If there's a current env value, then it must be the one that we set
+                    # in __enter__. Therefore, we want to remove it here to restore the
+                    # previous env var state (in which env was never set).
+                    del os.environ[env]
+                # If the env var isn't currently in the Environment variables state,
+                # then we had requested it temporarily unset in the context without
+                # the caller realizing that env was never set beforehand.
+                # Thus, this "reset" action for this case is equivalent to a no-op.
+        # forget about previous context setting
+        # could be used for another __enter__ --> __exit__ cycle, if desired
+        self.__prior_env_var_setting.clear()
+
+    def set(self) -> None:
+        """Alias for :func:`__enter__`."""
+        self.__enter__()
+
+    def unset(self) -> None:
+        """Alias for :func:`__exit__`."""
+        self.__exit__(None, None, None)  # type: ignore
+
+
+def _check_env_var_setting(env_var: Any, value: Any) -> Optional[str]:
+    """Ensures `env_var` is ok to set. Returns acceptable `value`. Raises `ValueError` otherwise."""
+    if not isinstance(env_var, str) or len(env_var) == 0:
+        raise ValueError(f"Need valid environment variable name, not ({type(env_var)}) '{env_var}'")
+    if value is None or isinstance(value, str):
+        new_val: Optional[str] = value
+    else:
+        if isinstance(value, (bytes, int, float, bool)):
+            new_val = str(value)
+        else:
+            raise ValueError(
+                f"Environment variable {env_var} must be either None, a string (str), or "
+                "a value that can be coerced into a string automatically "
+                f"(int, float, bool, bytes). Value is unacceptable {type(value)=}: {value}"
+            )
+
+    return new_val

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pywise"
-version = "0.4.0"
+version = "0.5.0"
 description = "Robust serialization support for NamedTuple & @dataclass data types."
 authors = ["Malcolm Greaves <greaves.malcolm@gmail.com>"]
 homepage = "https://github.com/malcolmgreaves/pywise"

--- a/tests/test_custom_serialization.py
+++ b/tests/test_custom_serialization.py
@@ -1,6 +1,6 @@
 import json
 from dataclasses import dataclass
-from typing import Tuple, NamedTuple, Mapping, Sequence
+from typing import Tuple, NamedTuple, Mapping, Sequence, Dict, Callable, Any
 
 import numpy as np
 from pytest import fixture, mark
@@ -20,7 +20,7 @@ def _pytorch_installed() -> bool:
 @fixture(scope="module")
 def custom_serialize() -> CustomFormat:
     np_ser = lambda arr: arr.tolist()
-    custom_format = {np.ndarray: np_ser}
+    custom_format: Dict[type, Callable[[Any], Any]] = {np.ndarray: np_ser}
     try:
         import torch
     except ImportError:
@@ -34,7 +34,7 @@ def custom_serialize() -> CustomFormat:
 @fixture(scope="module")
 def custom_deserialize() -> CustomFormat:
     np_deser = lambda lst: np.array(lst)
-    custom_format = {np.ndarray: np_deser}
+    custom_format: Dict[type, Callable[[Any], Any]] = {np.ndarray: np_deser}
     try:
         import torch
     except ImportError:

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,104 @@
+import os
+from typing import Any, Callable, Dict, Optional
+from uuid import uuid4
+from functools import partial
+
+import pytest
+
+from core_utils.env import Environment
+
+
+def _expect_not_present(e: str) -> None:
+    assert (
+        e not in os.environ
+    ), f"Not expecting env var {e} to be present, instead found {os.environ[e]}"
+
+
+def _expect_present(e: str, value: Any) -> None:
+    assert e in os.environ, f"Expecting env var {e} to be present with {value}"
+    assert (
+        os.environ[e] == value
+    ), f"Expected env var {e} to have value {value} but instead found {os.environ[e]}"
+
+
+def _prepare(e: str, existing: Optional[str]) -> Callable[[], None]:
+    if existing is not None:
+        os.environ[e] = existing
+        return partial(_expect_present, e, existing)
+    else:
+        return partial(_expect_not_present, e)
+
+
+def test_environment_kwarg():
+    e = "ENV_VAR_TEST"
+    _expect_not_present(e)
+    # NOTE: This is to test keyword argument use.
+    #       Make sure this **literal value** is the same as `e`'s contents.
+    with Environment(ENV_VAR_TEST="x"):
+        _expect_present(e, "x")
+    _expect_not_present(e)
+
+
+@pytest.mark.parametrize("existing", ["env var has prior value", None])
+def test_environment_normal_cases(existing):
+    e = f"___{uuid4()}-test_env_var"
+    check = _prepare(e, existing)
+
+    check()
+    new = f"{uuid4()}--hello_world"
+    with Environment(**{e: new}):
+        _expect_present(e, new)
+    check()
+
+
+def test_environment_unset():
+    k = f"___{uuid4()}___--test_unset_env_var--"
+    v = "hello world! how are you doing today?"
+    # when there is a previous value
+    try:
+        os.environ[k] = v
+        with Environment(**{k: None}):
+            assert k not in os.environ
+        assert k in os.environ
+        assert os.environ[k] == v
+    finally:
+        del os.environ[k]
+
+    # when there is not a previous value
+    assert k not in os.environ
+    with Environment(**{k: None}):
+        assert k not in os.environ
+    assert k not in os.environ
+
+
+def test_environment_multi():
+    env_vars: Dict[str, str] = {f"___{uuid4()}-test_env_var--{i}": f"value_{i}" for i in range(100)}
+
+    def ok():
+        for e in env_vars.keys():
+            _expect_not_present(e)
+
+    ok()
+    with Environment(**env_vars):
+        for e, v in env_vars.items():
+            _expect_present(e, v)
+    ok()
+
+
+def test_environment_invalid_states():
+    with pytest.raises(ValueError):
+        Environment(**{"": "2"})
+
+
+@pytest.mark.parametrize("existing", ["env var has prior value", None])
+def test_environment_with_exception(existing):
+    e = f"___{uuid4()}-test_env_var"
+    check = _prepare(e, existing)
+
+    check()
+    new = f"{uuid4()}--hello_world"
+    with pytest.raises(ValueError):
+        with Environment(**{e: new}):
+            _expect_present(e, new)
+            raise ValueError("Uh oh! Something went wrong in our context!")
+    check()


### PR DESCRIPTION
Adds a new context manager, `Environment`, that lets one temporarily set environment variables. Previous values for environment varialbes are captured before changing them, so that upon exit from the managed context, they are reset. During the context, observations on `os.environ` will show the new env var values. Intended use is with the following syntax:
```python
with Environment(A=..., B=...):
  # A and B have new values here
# A and B are reset to their previous values
```

Version bump to 0.5.1