### PR TITLE
Migrate to use `ruff` + standard `pre-commit-hooks`(Python,JSON,YAML)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,21 +2,14 @@
 #   - listed as dev-dependencies
 #   - version specifiers are **EXACTLY** the same
 repos:
-  - repo: https://github.com/psf/black
-    rev: 23.12.1
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.2
     hooks:
-      - id: black
-        name: "python:black"
+      - id: ruff
         args:
-          - --check
-  - repo: https://github.com/PyCQA/flake8
-    rev: 7.0.0
-    hooks:
-      - id: flake8
-        name: "python:flake8"
-        args:
-          - --max-line-length=100
-          - --ignore=E501,W293,E303,W291,W503,E203,E731,E231,E721,E722,E741
+          - --fix
+          - --line-length=100
+          - --ignore=E501,W293,E303,W291,E203,E731,E231,E721,E722,E741
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.10.0
     hooks:
@@ -28,5 +21,29 @@ repos:
           - --install-types
           - --non-interactive
           - --check-untyped-defs
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0  # https://github.com/pre-commit/pre-commit-hooks/releases
+    hooks:
+      - id: check-added-large-files
+        args:
+          - '--maxkb=1024' # 1MB file limit
+      - id: check-ast
+        language: python
+      - id: check-case-conflict
+        language: python
+      - id: check-json
+        language: python
+      - id: check-merge-conflict
+        language: python
+      - id: check-shebang-scripts-are-executable
+        language: python
+      - id: check-symlinks
+        language: python
+      - id: check-toml
+        language: python
+      - id: check-yaml
+        language: python
+        args:
+          - '--allow-multiple-documents'
 
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,7 @@ repos:
         args:
           - --follow-imports=silent
           - --show-column-numbers
+          - --ignore-missing-imports
           - --warn-unreachable
           - --install-types
           - --non-interactive

--- a/core_utils/common.py
+++ b/core_utils/common.py
@@ -1,5 +1,5 @@
 from importlib import import_module
-from typing import _GenericAlias, Any, Tuple, Optional, Type, TypeVar, get_args  # type: ignore
+from typing import Any, Optional, Tuple, Type, TypeVar, _GenericAlias, get_args  # type: ignore
 
 
 def type_name(t: type, keep_main: bool = True) -> str:

--- a/core_utils/schema.py
+++ b/core_utils/schema.py
@@ -1,24 +1,23 @@
+from dataclasses import is_dataclass
 from typing import (
-    Type,
-    Iterable,
-    Union,
     Any,
+    Callable,
+    Iterable,
     Mapping,
     Sequence,
-    get_args,
-    cast,
-    Callable,
     Tuple,
+    Type,
+    Union,
+    cast,
+    get_args,
 )
-from dataclasses import is_dataclass
 
-from core_utils.common import type_name, checkable_type
+from core_utils.common import checkable_type, type_name
 from core_utils.serialization import (
-    is_typed_namedtuple,
-    _namedtuple_field_types,
     _dataclass_field_types_defaults,
+    _namedtuple_field_types,
+    is_typed_namedtuple,
 )
-
 
 __all__ = ["dict_type_representation", "Discover"]
 

--- a/core_utils/serialization.py
+++ b/core_utils/serialization.py
@@ -1,27 +1,27 @@
 import traceback
+from dataclasses import _MISSING_TYPE, Field, dataclass, is_dataclass
 from enum import Enum
 from typing import (
     Any,
-    Iterable,
-    Type,
-    Tuple,
-    Set,
-    Mapping,
-    TypeVar,
     Callable,
-    Optional,
+    Dict,
+    Iterable,
     Iterator,
+    List,
+    Mapping,
+    Optional,
     Sequence,
-    get_origin,
-    get_args,
+    Set,
+    Tuple,
+    Type,
+    TypeVar,
     Union,
     cast,
-    List,
-    Dict,
+    get_args,
+    get_origin,
 )
-from dataclasses import dataclass, is_dataclass, Field, _MISSING_TYPE
 
-from core_utils.common import type_name, checkable_type, split_module_value
+from core_utils.common import checkable_type, split_module_value, type_name
 
 __all__ = [
     "serialize",

--- a/poetry.lock
+++ b/poetry.lock
@@ -41,52 +41,6 @@ files = [
 ]
 
 [[package]]
-name = "black"
-version = "23.12.1"
-description = "The uncompromising code formatter."
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "black-23.12.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e0aaf6041986767a5e0ce663c7a2f0e9eaf21e6ff87a5f95cbf3675bfd4c41d2"},
-    {file = "black-23.12.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c88b3711d12905b74206227109272673edce0cb29f27e1385f33b0163c414bba"},
-    {file = "black-23.12.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a920b569dc6b3472513ba6ddea21f440d4b4c699494d2e972a1753cdc25df7b0"},
-    {file = "black-23.12.1-cp310-cp310-win_amd64.whl", hash = "sha256:3fa4be75ef2a6b96ea8d92b1587dd8cb3a35c7e3d51f0738ced0781c3aa3a5a3"},
-    {file = "black-23.12.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8d4df77958a622f9b5a4c96edb4b8c0034f8434032ab11077ec6c56ae9f384ba"},
-    {file = "black-23.12.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:602cfb1196dc692424c70b6507593a2b29aac0547c1be9a1d1365f0d964c353b"},
-    {file = "black-23.12.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c4352800f14be5b4864016882cdba10755bd50805c95f728011bcb47a4afd59"},
-    {file = "black-23.12.1-cp311-cp311-win_amd64.whl", hash = "sha256:0808494f2b2df923ffc5723ed3c7b096bd76341f6213989759287611e9837d50"},
-    {file = "black-23.12.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:25e57fd232a6d6ff3f4478a6fd0580838e47c93c83eaf1ccc92d4faf27112c4e"},
-    {file = "black-23.12.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2d9e13db441c509a3763a7a3d9a49ccc1b4e974a47be4e08ade2a228876500ec"},
-    {file = "black-23.12.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d1bd9c210f8b109b1762ec9fd36592fdd528485aadb3f5849b2740ef17e674e"},
-    {file = "black-23.12.1-cp312-cp312-win_amd64.whl", hash = "sha256:ae76c22bde5cbb6bfd211ec343ded2163bba7883c7bc77f6b756a1049436fbb9"},
-    {file = "black-23.12.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1fa88a0f74e50e4487477bc0bb900c6781dbddfdfa32691e780bf854c3b4a47f"},
-    {file = "black-23.12.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:a4d6a9668e45ad99d2f8ec70d5c8c04ef4f32f648ef39048d010b0689832ec6d"},
-    {file = "black-23.12.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b18fb2ae6c4bb63eebe5be6bd869ba2f14fd0259bda7d18a46b764d8fb86298a"},
-    {file = "black-23.12.1-cp38-cp38-win_amd64.whl", hash = "sha256:c04b6d9d20e9c13f43eee8ea87d44156b8505ca8a3c878773f68b4e4812a421e"},
-    {file = "black-23.12.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3e1b38b3135fd4c025c28c55ddfc236b05af657828a8a6abe5deec419a0b7055"},
-    {file = "black-23.12.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4f0031eaa7b921db76decd73636ef3a12c942ed367d8c3841a0739412b260a54"},
-    {file = "black-23.12.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:97e56155c6b737854e60a9ab1c598ff2533d57e7506d97af5481141671abf3ea"},
-    {file = "black-23.12.1-cp39-cp39-win_amd64.whl", hash = "sha256:dd15245c8b68fe2b6bd0f32c1556509d11bb33aec9b5d0866dd8e2ed3dba09c2"},
-    {file = "black-23.12.1-py3-none-any.whl", hash = "sha256:78baad24af0f033958cad29731e27363183e140962595def56423e626f4bee3e"},
-    {file = "black-23.12.1.tar.gz", hash = "sha256:4ce3ef14ebe8d9509188014d96af1c456a910d5b5cbf434a09fef7e024b3d0d5"},
-]
-
-[package.dependencies]
-click = ">=8.0.0"
-mypy-extensions = ">=0.4.3"
-packaging = ">=22.0"
-pathspec = ">=0.9.0"
-platformdirs = ">=2"
-tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-typing-extensions = {version = ">=4.0.1", markers = "python_version < \"3.11\""}
-
-[package.extras]
-colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.7.4)", "aiohttp (>=3.7.4,!=3.9.0)"]
-jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
-uvloop = ["uvloop (>=0.15.2)"]
-
-[[package]]
 name = "cachetools"
 version = "5.3.3"
 description = "Extensible memoizing collections and decorators"
@@ -228,20 +182,6 @@ files = [
     {file = "charset_normalizer-3.3.2-cp39-cp39-win_amd64.whl", hash = "sha256:b01b88d45a6fcb69667cd6d2f7a9aeb4bf53760d7fc536bf679ec94fe9f3ff3d"},
     {file = "charset_normalizer-3.3.2-py3-none-any.whl", hash = "sha256:3e4d1f6587322d2788836a99c69062fbb091331ec940e02d12d179c1d53e25fc"},
 ]
-
-[[package]]
-name = "click"
-version = "8.1.7"
-description = "Composable command line interface toolkit"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28"},
-    {file = "click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"},
-]
-
-[package.dependencies]
-colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "colorama"
@@ -415,22 +355,6 @@ testing = ["covdefaults (>=2.3)", "coverage (>=7.3.2)", "diff-cover (>=8.0.1)", 
 typing = ["typing-extensions (>=4.8)"]
 
 [[package]]
-name = "flake8"
-version = "7.0.0"
-description = "the modular source code checker: pep8 pyflakes and co"
-optional = false
-python-versions = ">=3.8.1"
-files = [
-    {file = "flake8-7.0.0-py2.py3-none-any.whl", hash = "sha256:a6dfbb75e03252917f2473ea9653f7cd799c3064e54d4c8140044c5c065f53c3"},
-    {file = "flake8-7.0.0.tar.gz", hash = "sha256:33f96621059e65eec474169085dc92bf26e7b2d47366b70be2f67ab80dc25132"},
-]
-
-[package.dependencies]
-mccabe = ">=0.7.0,<0.8.0"
-pycodestyle = ">=2.11.0,<2.12.0"
-pyflakes = ">=3.2.0,<3.3.0"
-
-[[package]]
 name = "identify"
 version = "2.5.36"
 description = "File identification library for Python"
@@ -522,20 +446,6 @@ test = ["pytest (<7.1)", "pytest-asyncio", "testpath"]
 test-extra = ["curio", "matplotlib (!=3.2.0)", "nbformat", "numpy (>=1.21)", "pandas", "pytest (<7.1)", "pytest-asyncio", "testpath", "trio"]
 
 [[package]]
-name = "isort"
-version = "5.13.2"
-description = "A Python utility / library to sort Python imports."
-optional = false
-python-versions = ">=3.8.0"
-files = [
-    {file = "isort-5.13.2-py3-none-any.whl", hash = "sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6"},
-    {file = "isort-5.13.2.tar.gz", hash = "sha256:48fdfcb9face5d58a4f6dde2e72a1fb8dcaf8ab26f95ab49fab84c2ddefb0109"},
-]
-
-[package.extras]
-colors = ["colorama (>=0.4.6)"]
-
-[[package]]
 name = "jedi"
 version = "0.19.1"
 description = "An autocompletion tool for Python that can be used for text editors."
@@ -567,17 +477,6 @@ files = [
 
 [package.dependencies]
 traitlets = "*"
-
-[[package]]
-name = "mccabe"
-version = "0.7.0"
-description = "McCabe checker, plugin for flake8"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
-    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
-]
 
 [[package]]
 name = "mypy"
@@ -715,17 +614,6 @@ qa = ["flake8 (==5.0.4)", "mypy (==0.971)", "types-setuptools (==67.2.0.1)"]
 testing = ["docopt", "pytest"]
 
 [[package]]
-name = "pathspec"
-version = "0.12.1"
-description = "Utility library for gitignore style pattern matching of file paths."
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08"},
-    {file = "pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"},
-]
-
-[[package]]
 name = "pexpect"
 version = "4.9.0"
 description = "Pexpect allows easy control of interactive console applications."
@@ -837,28 +725,6 @@ files = [
 
 [package.extras]
 tests = ["pytest"]
-
-[[package]]
-name = "pycodestyle"
-version = "2.11.1"
-description = "Python style guide checker"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "pycodestyle-2.11.1-py2.py3-none-any.whl", hash = "sha256:44fe31000b2d866f2e41841b18528a505fbd7fef9017b04eff4e2648a0fadc67"},
-    {file = "pycodestyle-2.11.1.tar.gz", hash = "sha256:41ba0e7afc9752dfb53ced5489e89f8186be00e599e712660695b7a75ff2663f"},
-]
-
-[[package]]
-name = "pyflakes"
-version = "3.2.0"
-description = "passive checker of Python programs"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "pyflakes-3.2.0-py2.py3-none-any.whl", hash = "sha256:84b5be138a2dfbb40689ca07e2152deb896a65c3a3e24c251c5c62489568074a"},
-    {file = "pyflakes-3.2.0.tar.gz", hash = "sha256:1c61603ff154621fb2a9172037d84dca3500def8c8b630657d1701f026f8af3f"},
-]
 
 [[package]]
 name = "pygments"
@@ -1201,4 +1067,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.1"
-content-hash = "2c6c5ba0759925fd9f48cb16d357282742c23bb84a42c178ab183bd3f2c5042c"
+content-hash = "c88995fce6eb10f4240d5ef2a35f2051119b1e29cb3c88da83a0e730f81c423a"

--- a/poetry.lock
+++ b/poetry.lock
@@ -522,6 +522,20 @@ test = ["pytest (<7.1)", "pytest-asyncio", "testpath"]
 test-extra = ["curio", "matplotlib (!=3.2.0)", "nbformat", "numpy (>=1.21)", "pandas", "pytest (<7.1)", "pytest-asyncio", "testpath", "trio"]
 
 [[package]]
+name = "isort"
+version = "5.13.2"
+description = "A Python utility / library to sort Python imports."
+optional = false
+python-versions = ">=3.8.0"
+files = [
+    {file = "isort-5.13.2-py3-none-any.whl", hash = "sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6"},
+    {file = "isort-5.13.2.tar.gz", hash = "sha256:48fdfcb9face5d58a4f6dde2e72a1fb8dcaf8ab26f95ab49fab84c2ddefb0109"},
+]
+
+[package.extras]
+colors = ["colorama (>=0.4.6)"]
+
+[[package]]
 name = "jedi"
 version = "0.19.1"
 description = "An autocompletion tool for Python that can be used for text editors."
@@ -1001,6 +1015,32 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
+name = "ruff"
+version = "0.4.2"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ruff-0.4.2-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:8d14dc8953f8af7e003a485ef560bbefa5f8cc1ad994eebb5b12136049bbccc5"},
+    {file = "ruff-0.4.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:24016ed18db3dc9786af103ff49c03bdf408ea253f3cb9e3638f39ac9cf2d483"},
+    {file = "ruff-0.4.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0e2e06459042ac841ed510196c350ba35a9b24a643e23db60d79b2db92af0c2b"},
+    {file = "ruff-0.4.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3afabaf7ba8e9c485a14ad8f4122feff6b2b93cc53cd4dad2fd24ae35112d5c5"},
+    {file = "ruff-0.4.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:799eb468ea6bc54b95527143a4ceaf970d5aa3613050c6cff54c85fda3fde480"},
+    {file = "ruff-0.4.2-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:ec4ba9436a51527fb6931a8839af4c36a5481f8c19e8f5e42c2f7ad3a49f5069"},
+    {file = "ruff-0.4.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6a2243f8f434e487c2a010c7252150b1fdf019035130f41b77626f5655c9ca22"},
+    {file = "ruff-0.4.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8772130a063f3eebdf7095da00c0b9898bd1774c43b336272c3e98667d4fb8fa"},
+    {file = "ruff-0.4.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6ab165ef5d72392b4ebb85a8b0fbd321f69832a632e07a74794c0e598e7a8376"},
+    {file = "ruff-0.4.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:1f32cadf44c2020e75e0c56c3408ed1d32c024766bd41aedef92aa3ca28eef68"},
+    {file = "ruff-0.4.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:22e306bf15e09af45ca812bc42fa59b628646fa7c26072555f278994890bc7ac"},
+    {file = "ruff-0.4.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:82986bb77ad83a1719c90b9528a9dd663c9206f7c0ab69282af8223566a0c34e"},
+    {file = "ruff-0.4.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:652e4ba553e421a6dc2a6d4868bc3b3881311702633eb3672f9f244ded8908cd"},
+    {file = "ruff-0.4.2-py3-none-win32.whl", hash = "sha256:7891ee376770ac094da3ad40c116258a381b86c7352552788377c6eb16d784fe"},
+    {file = "ruff-0.4.2-py3-none-win_amd64.whl", hash = "sha256:5ec481661fb2fd88a5d6cf1f83403d388ec90f9daaa36e40e2c003de66751798"},
+    {file = "ruff-0.4.2-py3-none-win_arm64.whl", hash = "sha256:cbd1e87c71bca14792948c4ccb51ee61c3296e164019d2d484f3eaa2d360dfaf"},
+    {file = "ruff-0.4.2.tar.gz", hash = "sha256:33bcc160aee2520664bc0859cfeaebc84bb7323becff3f303b8f1f2d81cb4edc"},
+]
+
+[[package]]
 name = "setuptools"
 version = "69.5.1"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
@@ -1161,4 +1201,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.1"
-content-hash = "eb7dc2a7b201a9efbf6ada352ca73668e5125e4950da2c734aa0a925fc781b27"
+content-hash = "2c6c5ba0759925fd9f48cb16d357282742c23bb84a42c178ab183bd3f2c5042c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,7 @@ python = "^3.8.1"
 pre-commit = "^3.5.0"
 # keep in-sync with .pre-commit-config.yaml
 mypy = "^1.10.0"
-black = "^23.12.1"
-flake8 = "^7.0.0"
+ruff = "^0.4.2"
 # end sync
 # testing related
 pytest-cov = "^4.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,101 @@ pyyaml = "*"
 ipython = "*"
 ipdb = "*"
 
-[tool.black]
+[tool.ruff]
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+]
+
+# Same as Black.
 line-length = 100
+indent-width = 4
+
+
+# Assume Python 3.8
+target-version = "py38"
+
+[tool.ruff.lint]
+
+# pyflakes, pycodestyle, isort
+select = ["F", "E", "W", "I001"]
+
+# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
+# Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
+# McCabe complexity (`C901`) by default.
+#select = ["E4", "E7", "E9", "F"]
+
+ignore = [
+    "E501",
+    "W293",
+    "E303",
+    "W291",
+    "E203",
+    "E731",
+    "E231",
+    "E721",
+    "E722",
+    "E741",
+]
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+## Allow unused variables when underscore-prefixed.
+#dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[tool.ruff.format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"
+
+# Enable auto-formatting of code examples in docstrings. Markdown,
+# reStructuredText code/literal blocks and doctests are all supported.
+#
+# This is currently disabled by default, but it is planned for this
+# to be opt-out in the future.
+docstring-code-format = true
+
+# Set the line length limit used when formatting code snippets in
+# docstrings.
+#
+# This only has an effect when the `docstring-code-format` setting is
+# enabled.
+docstring-code-line-length = "dynamic"
 
 [build-system]
 requires = ["poetry>=1.0"]

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,21 +1,21 @@
+import typing
 from dataclasses import dataclass
 from pathlib import Path
 from typing import (
-    NamedTuple,
-    Union,
-    Optional,
-    Generic,
-    TypeVar,
-    Sequence,
-    Mapping,
     Dict,
+    Generic,
     List,
+    Mapping,
+    NamedTuple,
+    Optional,
+    Sequence,
+    TypeVar,
+    Union,
 )
 
-import typing
 from pytest import raises
 
-from core_utils.common import type_name, import_by_name, checkable_type
+from core_utils.common import checkable_type, import_by_name, type_name
 
 
 class NTX(NamedTuple):

--- a/tests/test_custom_serialization.py
+++ b/tests/test_custom_serialization.py
@@ -1,11 +1,11 @@
 import json
 from dataclasses import dataclass
-from typing import Tuple, NamedTuple, Mapping, Sequence, Dict, Callable, Any
+from typing import Any, Callable, Dict, Mapping, NamedTuple, Sequence, Tuple
 
 import numpy as np
 from pytest import fixture, mark
 
-from core_utils.serialization import CustomFormat, serialize, deserialize
+from core_utils.serialization import CustomFormat, deserialize, serialize
 
 
 def _pytorch_installed() -> bool:

--- a/tests/test_dataclass_with_generic.py
+++ b/tests/test_dataclass_with_generic.py
@@ -1,18 +1,17 @@
-from typing import Tuple, Any, Type, List, Mapping
+from typing import Any, List, Mapping, Tuple, Type
 
 from pytest import fixture
 
-from core_utils.support_for_testing import (
-    SimpleGeneric,
-    NestedGeneric,
-    SimpleNoGen,
-    NestedNoGen,
-)
-
 from core_utils.serialization import (
-    serialize,
-    deserialize,
     _align_generic_concrete,
+    deserialize,
+    serialize,
+)
+from core_utils.support_for_testing import (
+    NestedGeneric,
+    NestedNoGen,
+    SimpleGeneric,
+    SimpleNoGen,
 )
 
 

--- a/tests/test_deserialize_unions_with_collections.py
+++ b/tests/test_deserialize_unions_with_collections.py
@@ -1,8 +1,9 @@
+from dataclasses import dataclass
+from typing import Mapping, Sequence, Union
+
 import pytest
 
-from core_utils.serialization import serialize, deserialize
-from dataclasses import dataclass
-from typing import Union, Sequence, Mapping
+from core_utils.serialization import deserialize, serialize
 
 
 @dataclass(frozen=True)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,7 +1,7 @@
 import os
+from functools import partial
 from typing import Any, Callable, Dict, Optional
 from uuid import uuid4
-from functools import partial
 
 import pytest
 
@@ -101,4 +101,5 @@ def test_environment_with_exception(existing):
         with Environment(**{e: new}):
             _expect_present(e, new)
             raise ValueError("Uh oh! Something went wrong in our context!")
-    check()
+    # unreachable
+    check()  # type: ignore

--- a/tests/test_readme_example.py
+++ b/tests/test_readme_example.py
@@ -1,11 +1,11 @@
 import json
-from typing import Optional, Union, Sequence, NamedTuple
 from dataclasses import dataclass
 from enum import Enum, auto
+from typing import NamedTuple, Optional, Sequence, Union
 
 from pytest import fixture
 
-from core_utils.serialization import serialize, deserialize
+from core_utils.serialization import deserialize, serialize
 
 
 @dataclass(frozen=True)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,9 +1,8 @@
 import json
-from typing import NamedTuple, Sequence, Optional, Mapping
 from dataclasses import dataclass
+from typing import Mapping, NamedTuple, Optional, Sequence
 
 from core_utils.schema import dict_type_representation
-
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 #                        Shared Test Helpers                        #

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -3,22 +3,21 @@ import json
 from collections import namedtuple
 from dataclasses import dataclass
 from enum import Enum, IntEnum
-from typing import NamedTuple, Sequence, Optional, Mapping, Set, Tuple, Union, Any
+from typing import Any, Mapping, NamedTuple, Optional, Sequence, Set, Tuple, Union
 
-from pytest import raises, fixture
 import yaml
-
+from pytest import fixture, raises
 
 from core_utils.serialization import (
-    serialize,
+    FieldDeserializeFail,
+    MissingRequired,
+    _dataclass_from_dict,
+    _is_optional,
+    _namedtuple_from_dict,
     deserialize,
     is_namedtuple,
     is_typed_namedtuple,
-    _namedtuple_from_dict,
-    _is_optional,
-    FieldDeserializeFail,
-    _dataclass_from_dict,
-    MissingRequired,
+    serialize,
 )
 
 


### PR DESCRIPTION
Replace `black` and `flake8` with `ruff`. Also add support for import ordering (like `isort`, but `ruff` replaces). Using `ruff` is orders of magnitude faster than using any single one of the tools it replaces. It also centralizes the configuration and execution of them.

Adds `ruff` as a pre-commit hook.

Additionally, adds new standard `pre-commit-hooks` with support for Python, JSON, and YAML.

Applies all new `ruff` formatting rules (using `ruff check --fix`).